### PR TITLE
Fix modeSelectors producing invalid CSS for at-rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 2.0.0-alpha.9
+
+### Fixed
+
+- **`modeSelectors` no longer produces invalid CSS for at-rules** (#29). Passing
+  a `@media` or `@supports` query as a `modeSelectors` value now automatically
+  wraps variables in `:root` inside the at-rule block. Previously, variables were
+  placed directly inside the at-rule with no selector, producing CSS that browsers
+  silently ignored.
+
+### Added
+
+- **`ModeSelector` object form** for `modeSelectors` values. Use
+  `{ atRule: "@media ...", selector: ".app" }` to control both the at-rule wrapper
+  and the inner selector. The `selector` field defaults to `:root`.
+
 ## 2.0.0-alpha.8
 
 ### Breaking Changes

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@shawnrice/teikn",
-  "version": "2.0.0-alpha.8",
+  "version": "2.0.0-alpha.9",
   "exports": {
     ".": "./index.ts",
     "./builders": "./src/builders.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teikn",
-  "version": "2.0.0-alpha.8",
+  "version": "2.0.0-alpha.9",
   "description": "Generate design tokens",
   "keywords": [
     "design",

--- a/src/Generators/CssVars.test.ts
+++ b/src/Generators/CssVars.test.ts
@@ -137,7 +137,12 @@ describe("CssVars Generator tests", () => {
       },
     });
     const tokens: Token[] = [
-      { name: "bg", type: "color", value: "#ffffff", modes: { dark: "#1a1a1a", contrast: "#000000" } },
+      {
+        name: "bg",
+        type: "color",
+        value: "#ffffff",
+        modes: { dark: "#1a1a1a", contrast: "#000000" },
+      },
     ];
     const output = gen.generate(tokens);
     // at-rule gets :root wrapper

--- a/src/Generators/CssVars.test.ts
+++ b/src/Generators/CssVars.test.ts
@@ -79,4 +79,72 @@ describe("CssVars Generator tests", () => {
     expect(output).toContain(".dark {");
     expect(output).not.toContain('[data-theme="dark"]');
   });
+
+  test("modeSelectors wraps at-rule strings in :root", () => {
+    const gen = new Generator({
+      ...testOpts,
+      modeSelectors: { dark: "@media (prefers-color-scheme: dark)" },
+    });
+    const tokens: Token[] = [
+      { name: "bg", type: "color", value: "#ffffff", modes: { dark: "#1a1a1a" } },
+    ];
+    const output = gen.generate(tokens);
+    expect(output).toContain("@media (prefers-color-scheme: dark) {");
+    expect(output).toContain("  :root {");
+    expect(output).toContain("    --bg: #1a1a1a;");
+    expect(output).toMatchSnapshot();
+  });
+
+  test("modeSelectors object form uses custom selector inside at-rule", () => {
+    const gen = new Generator({
+      ...testOpts,
+      modeSelectors: {
+        dark: { atRule: "@media (prefers-color-scheme: dark)", selector: ".app" },
+      },
+    });
+    const tokens: Token[] = [
+      { name: "bg", type: "color", value: "#ffffff", modes: { dark: "#1a1a1a" } },
+    ];
+    const output = gen.generate(tokens);
+    expect(output).toContain("@media (prefers-color-scheme: dark) {");
+    expect(output).toContain("  .app {");
+    expect(output).toContain("    --bg: #1a1a1a;");
+    expect(output).toMatchSnapshot();
+  });
+
+  test("modeSelectors object form defaults selector to :root", () => {
+    const gen = new Generator({
+      ...testOpts,
+      modeSelectors: {
+        dark: { atRule: "@media (prefers-color-scheme: dark)" },
+      },
+    });
+    const tokens: Token[] = [
+      { name: "bg", type: "color", value: "#ffffff", modes: { dark: "#1a1a1a" } },
+    ];
+    const output = gen.generate(tokens);
+    expect(output).toContain("@media (prefers-color-scheme: dark) {");
+    expect(output).toContain("  :root {");
+    expect(output).toContain("    --bg: #1a1a1a;");
+  });
+
+  test("modeSelectors handles mix of selectors and at-rules", () => {
+    const gen = new Generator({
+      ...testOpts,
+      modeSelectors: {
+        dark: "@media (prefers-color-scheme: dark)",
+        contrast: ".high-contrast",
+      },
+    });
+    const tokens: Token[] = [
+      { name: "bg", type: "color", value: "#ffffff", modes: { dark: "#1a1a1a", contrast: "#000000" } },
+    ];
+    const output = gen.generate(tokens);
+    // at-rule gets :root wrapper
+    expect(output).toContain("@media (prefers-color-scheme: dark) {");
+    expect(output).toContain("  :root {");
+    // plain selector stays flat
+    expect(output).toContain(".high-contrast {");
+    expect(output).toMatchSnapshot();
+  });
 });

--- a/src/Generators/CssVars.ts
+++ b/src/Generators/CssVars.ts
@@ -13,12 +13,30 @@ const defaultOptions = {
   dateFn: getDate,
 };
 
+export type ModeSelector = string | { atRule: string; selector?: string };
+
 export type CssVarsOpts = {
   nameTransformer?: (name: string) => string;
   dateFn?: () => string | null;
   useMediaQuery?: boolean;
-  modeSelectors?: Record<string, string>;
+  modeSelectors?: Record<string, ModeSelector>;
 } & GeneratorOptions;
+
+const parseModeSelector = (
+  raw: ModeSelector | undefined,
+  mode: string,
+): { atRule: string | null; selector: string } => {
+  if (raw == null) {
+    return { atRule: null, selector: `[data-theme="${mode}"]` };
+  }
+  if (typeof raw === "object") {
+    return { atRule: raw.atRule, selector: raw.selector ?? ":root" };
+  }
+  if (raw.startsWith("@")) {
+    return { atRule: raw, selector: ":root" };
+  }
+  return { atRule: null, selector: raw };
+};
 
 export class CssVars extends Generator<CssVarsOpts> {
   constructor(options = {}) {
@@ -64,10 +82,17 @@ export class CssVars extends Generator<CssVarsOpts> {
 
     for (const [mode, vars] of modeMap) {
       const { useMediaQuery, modeSelectors } = this.options;
-      const selector = modeSelectors?.[mode] ?? `[data-theme="${mode}"]`;
-      blocks.push("", `${selector} {`, vars.join(EOL), `}`);
+      const raw = modeSelectors?.[mode];
+      const { atRule, selector } = parseModeSelector(raw, mode);
 
-      if (useMediaQuery && mode === "dark") {
+      if (atRule) {
+        const indented = vars.map((v) => `  ${v}`);
+        blocks.push("", `${atRule} {`, `  ${selector} {`, indented.join(EOL), `  }`, `}`);
+      } else {
+        blocks.push("", `${selector} {`, vars.join(EOL), `}`);
+      }
+
+      if (useMediaQuery && mode === "dark" && !atRule) {
         const indented = vars.map((v) => `  ${v}`);
         blocks.push(
           "",

--- a/src/Generators/CssVars.vitest.snap
+++ b/src/Generators/CssVars.vitest.snap
@@ -34,3 +34,61 @@ exports[`CssVars Generator tests > It generates themed tokens with modes 1`] = `
   --text: #eeeeee;
 }"
 `;
+
+exports[`CssVars Generator tests > modeSelectors handles mix of selectors and at-rules 1`] = `
+"/**
+ * Teikn vtest
+ * Generated null
+ *
+ * This file is generated and should be committed to source control
+ */
+:root {
+  --bg: #ffffff;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #1a1a1a;
+  }
+}
+
+.high-contrast {
+  --bg: #000000;
+}"
+`;
+
+exports[`CssVars Generator tests > modeSelectors object form uses custom selector inside at-rule 1`] = `
+"/**
+ * Teikn vtest
+ * Generated null
+ *
+ * This file is generated and should be committed to source control
+ */
+:root {
+  --bg: #ffffff;
+}
+
+@media (prefers-color-scheme: dark) {
+  .app {
+    --bg: #1a1a1a;
+  }
+}"
+`;
+
+exports[`CssVars Generator tests > modeSelectors wraps at-rule strings in :root 1`] = `
+"/**
+ * Teikn vtest
+ * Generated null
+ *
+ * This file is generated and should be committed to source control
+ */
+:root {
+  --bg: #ffffff;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #1a1a1a;
+  }
+}"
+`;

--- a/src/Generators/__snapshots__/CssVars.test.ts.snap
+++ b/src/Generators/__snapshots__/CssVars.test.ts.snap
@@ -34,3 +34,61 @@ exports[`CssVars Generator tests It generates themed tokens with modes 1`] = `
   --text: #eeeeee;
 }"
 `;
+
+exports[`CssVars Generator tests modeSelectors wraps at-rule strings in :root 1`] = `
+"/**
+ * Teikn vtest
+ * Generated null
+ *
+ * This file is generated and should be committed to source control
+ */
+:root {
+  --bg: #ffffff;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #1a1a1a;
+  }
+}"
+`;
+
+exports[`CssVars Generator tests modeSelectors object form uses custom selector inside at-rule 1`] = `
+"/**
+ * Teikn vtest
+ * Generated null
+ *
+ * This file is generated and should be committed to source control
+ */
+:root {
+  --bg: #ffffff;
+}
+
+@media (prefers-color-scheme: dark) {
+  .app {
+    --bg: #1a1a1a;
+  }
+}"
+`;
+
+exports[`CssVars Generator tests modeSelectors handles mix of selectors and at-rules 1`] = `
+"/**
+ * Teikn vtest
+ * Generated null
+ *
+ * This file is generated and should be committed to source control
+ */
+:root {
+  --bg: #ffffff;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #1a1a1a;
+  }
+}
+
+.high-contrast {
+  --bg: #000000;
+}"
+`;

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const version = "2.0.0-alpha.8";
+export const version = "2.0.0-alpha.9";


### PR DESCRIPTION
## Summary

Closes #29.

- `modeSelectors` values starting with `@` (e.g. `@media (prefers-color-scheme: dark)`) now automatically wrap variables in `:root` inside the at-rule, producing valid CSS
- New `ModeSelector` object form `{ atRule: string; selector?: string }` gives full control over the inner selector (defaults to `:root`) — useful for `@container` queries or scoped design systems
- Guards `useMediaQuery` so it doesn't emit a duplicate media query block when `modeSelectors` already provides one
