### PR TITLE
Pre-beta hardening for 2.0.0-beta.0

### DIFF
--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@shawnrice/teikn",
-  "version": "2.0.0-alpha.14",
+  "version": "2.0.0-beta.0",
   "exports": {
     ".": "./index.ts",
     "./builders": "./src/builders.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teikn",
-  "version": "2.0.0-alpha.14",
+  "version": "2.0.0-beta.0",
   "description": "Generate design tokens",
   "keywords": [
     "design",

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -35,10 +35,20 @@ fi
 
 echo "$CURRENT → $NEW_VERSION"
 
-# Update all three files
-sed -i '' "s/\"version\": \"$CURRENT\"/\"version\": \"$NEW_VERSION\"/" "$ROOT/package.json"
-sed -i '' "s/\"version\": \"$CURRENT\"/\"version\": \"$NEW_VERSION\"/" "$ROOT/jsr.json"
-sed -i '' "s/export const version = \"$CURRENT\"/export const version = \"$NEW_VERSION\"/" "$ROOT/src/version.ts"
+# Portable in-place edit: BSD sed wants `-i ''`, GNU sed parses that as a
+# missing file. Use a temp file + mv instead — works in both, atomic.
+replace_in_file() {
+  local pattern="$1"
+  local file="$2"
+  local tmp
+  tmp="$(mktemp "${file}.XXXXXX")"
+  sed "$pattern" "$file" > "$tmp"
+  mv "$tmp" "$file"
+}
+
+replace_in_file "s/\"version\": \"$CURRENT\"/\"version\": \"$NEW_VERSION\"/" "$ROOT/package.json"
+replace_in_file "s/\"version\": \"$CURRENT\"/\"version\": \"$NEW_VERSION\"/" "$ROOT/jsr.json"
+replace_in_file "s/export const version = \"$CURRENT\"/export const version = \"$NEW_VERSION\"/" "$ROOT/src/version.ts"
 
 # Verify
 for file in package.json jsr.json src/version.ts; do

--- a/src/Generators/Generator.ts
+++ b/src/Generators/Generator.ts
@@ -156,6 +156,14 @@ export abstract class Generator<Opts extends GeneratorOptions = GeneratorOptions
       }
     }
 
+    const { filename } = this.options;
+    if (typeof filename === "string" && /[\\/]|(^|\/)\.\.($|\/)/.test(filename)) {
+      errors.push(
+        `Error: filename "${filename}" must not contain path separators (\`/\`, \`\\\`) or \`..\` segments. ` +
+          `Use the \`outDir\` option to control the output directory.`,
+      );
+    }
+
     if (errors.length) {
       throw new Error(errors.join(EOL));
     }

--- a/src/Generators/Generator.ts
+++ b/src/Generators/Generator.ts
@@ -3,6 +3,7 @@ import { EOL } from "node:os";
 import { version } from "../version.js";
 import { sortPlugins } from "../Plugins/Plugin.js";
 import type { Plugin } from "../Plugins/index.js";
+import { resolveReferences } from "../resolve.js";
 import { camelCase, deriveShortName } from "../string-utils.js";
 import type { ModeValues, Token, TokenValue } from "../Token.js";
 import { isFirstClassValue } from "../type-classifiers.js";
@@ -314,8 +315,19 @@ export abstract class Generator<Opts extends GeneratorOptions = GeneratorOptions
 
   abstract combinator(_: Token[]): string;
 
+  /**
+   * @internal Use {@link Teikn.generateToStrings} (or {@link Teikn.transform})
+   * instead. Calling `generate` directly is supported for testing but is not
+   * part of the stable public API; behavior may change between versions.
+   *
+   * Resolves references defensively so plugins always see materialized values,
+   * regardless of whether the caller pre-resolved.
+   * `resolveReferences` is idempotent on already-resolved tokens, so calling
+   * this from inside `Teikn.generateToStrings` (which also resolves) is safe.
+   */
   generate(tokens: Token[], plugins: Plugin[] = []): string {
-    return [this.header(), this.combinator(this.prepareTokens(tokens, plugins)), this.footer()]
+    const resolved = resolveReferences(tokens);
+    return [this.header(), this.combinator(this.prepareTokens(resolved, plugins)), this.footer()]
       .filter(Boolean)
       .join(EOL)
       .trim();
@@ -334,9 +346,10 @@ export abstract class Generator<Opts extends GeneratorOptions = GeneratorOptions
   }
 
   /**
-   * Produce the full set of generated files keyed by filename. Default
-   * implementation emits a single file at {@link file} with the output of
-   * {@link generate}. Generators that emit multiple files override this.
+   * @internal Use {@link Teikn.generateToStrings} instead. Produces the full
+   * set of generated files keyed by filename. Default impl emits a single
+   * file at {@link file} with the output of {@link generate}. Multi-file
+   * generators (TypeScript meta) override.
    */
   generateFiles(tokens: Token[], plugins: Plugin[] = []): Map<string, string> {
     return new Map([[this.file, this.generate(tokens, plugins)]]);

--- a/src/Generators/Generator.ts
+++ b/src/Generators/Generator.ts
@@ -8,8 +8,20 @@ import type { ModeValues, Token, TokenValue } from "../Token.js";
 import { isFirstClassValue } from "../type-classifiers.js";
 import { matches } from "../utils.js";
 
+const runTransform = (plugin: Plugin, input: Token, contextTokenName: string): Token => {
+  try {
+    return plugin.transform(input);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    throw new Error(
+      `Plugin \`${plugin.constructor.name}\` threw while processing token \`${contextTokenName}\`: ${msg}`,
+      { cause: e },
+    );
+  }
+};
+
 export const applyPlugin = (plugin: Plugin, token: Token): Token => {
-  const transformed = plugin.transform(token);
+  const transformed = runTransform(plugin, token, token.name);
 
   if (!transformed || typeof transformed !== "object" || !transformed.name || !transformed.type) {
     throw new Error(
@@ -30,7 +42,7 @@ export const applyPlugin = (plugin: Plugin, token: Token): Token => {
   for (const [mode, modeVal] of Object.entries(sourceModes)) {
     const { modes: _, ...rest } = transformed;
     const syntheticToken = { ...rest, value: modeVal };
-    transformedModes[mode] = plugin.transform(syntheticToken).value;
+    transformedModes[mode] = runTransform(plugin, syntheticToken, token.name).value;
   }
 
   return { ...transformed, modes: transformedModes };

--- a/src/Generators/JavaScript.ts
+++ b/src/Generators/JavaScript.ts
@@ -81,11 +81,15 @@ export class JavaScript extends Generator<JavaScriptOpts> {
   generateToken(token: Token): string {
     const { nameTransformer } = this.options;
     const key = quoteKey(nameTransformer!(token.name));
+    const deprecationTag = token.deprecated
+      ? `   *  @deprecated${token.replacement ? ` use \`${nameTransformer!(token.replacement)}\` instead` : ""}`
+      : null;
 
     return [
       `  /**`,
       token.usage && `   *  ${token.usage}`,
       `   *  Type: ${token.type}`,
+      deprecationTag,
       `   */`,
       `  ${key}: ${maybeQuote(token.value)},`,
     ]

--- a/src/Generators/Scss.ts
+++ b/src/Generators/Scss.ts
@@ -7,6 +7,7 @@ import { getDate } from "../utils.js";
 import type { GeneratorInfo, GeneratorOptions } from "./Generator.js";
 import { Generator } from "./Generator.js";
 import type { PrefixOptions } from "./prefix-utils.js";
+import { composeSymbol } from "./prefix-utils.js";
 import { cssMapValue } from "./value-serializers.js";
 
 const defaultOptions = {
@@ -38,22 +39,25 @@ export class Scss extends Generator<ScssOpts> {
     };
   }
 
+  #emit(name: string): string {
+    const { nameTransformer } = this.options;
+    return composeSymbol(name, nameTransformer!, this.options);
+  }
+
   override tokenUsage(token: Token): string | null {
-    const { nameTransformer, groups } = this.options;
+    const { groups } = this.options;
     if (groups) {
       const shortName = deriveShortName(token.name, token.type);
       const groupName = camelCase(token.type);
       const groupKebab = kebabCase(groupName);
       return `${groupKebab}('${kebabCase(shortName)}')`;
     }
-    return `get-token('${nameTransformer!(token.name)}')`;
+    return `get-token('${this.#emit(token.name)}')`;
   }
 
   generateToken(token: Token): string {
-    const { nameTransformer } = this.options;
-
     const { usage, value } = token;
-    const key = nameTransformer!(token.name);
+    const key = this.#emit(token.name);
 
     // prettier-ignore
     return [
@@ -107,7 +111,6 @@ export class Scss extends Generator<ScssOpts> {
       return null;
     }
 
-    const { nameTransformer } = this.options;
     const groups = this.tokenGroups(tokens);
 
     return groups
@@ -116,7 +119,7 @@ export class Scss extends Generator<ScssOpts> {
         const mapEntries = entries
           .map(
             ({ shortName, token }) =>
-              `  ${kebabCase(shortName)}: map.get($token-values, ${nameTransformer!(token.name)}),`,
+              `  ${kebabCase(shortName)}: map.get($token-values, ${this.#emit(token.name)}),`,
           )
           .join(EOL);
         return [

--- a/src/Generators/TypeScript.test.ts
+++ b/src/Generators/TypeScript.test.ts
@@ -55,9 +55,9 @@ describe("TypeScript meta generator", () => {
     expect(dts).toContain('readonly colorSecondary: "#999999";');
   });
 
-  test("module: 'cjs' switches the runtime file to .cjs + module.exports", () => {
+  test("module: 'cjs' switches the runtime file to .cjs + module.exports and declarations to .d.cts", () => {
     const files = new TypeScript({ dateFn: fixedDate, module: "cjs" }).generateFiles(sampleTokens);
-    expect([...files.keys()].toSorted()).toEqual(["tokens.cjs", "tokens.d.ts"]);
+    expect([...files.keys()].toSorted()).toEqual(["tokens.cjs", "tokens.d.cts"]);
     const cjs = files.get("tokens.cjs")!;
     expect(cjs).toContain("const tokens = {");
     expect(cjs).toContain("module.exports = { tokens: tokens, default: tokens };");

--- a/src/Generators/TypeScript.ts
+++ b/src/Generators/TypeScript.ts
@@ -58,8 +58,10 @@ export class TypeScript extends Generator<TypeScriptOpts> {
 
     super({ ...defaultOptions, ...options });
 
-    // `module` is JavaScript-only, `loose` is TypeScriptDeclarations-only;
-    // strip before forwarding shared opts.
+    // `loose` is TypeScriptDeclarations-only; `module` propagates to both
+    // (JavaScript picks the runtime ext; TypeScriptDeclarations picks
+    // `.d.cts` vs `.d.ts` so Node's strict resolvers find declarations
+    // alongside the runtime).
     const { loose, module: moduleKind, ...shared } = options;
     this.#javascript = new JavaScript({
       ...shared,
@@ -68,6 +70,7 @@ export class TypeScript extends Generator<TypeScriptOpts> {
     this.#declarations = new TypeScriptDeclarations({
       ...shared,
       ...(loose !== undefined && { loose }),
+      ...(moduleKind !== undefined && { module: moduleKind }),
     });
   }
 

--- a/src/Generators/TypeScriptDeclarations.ts
+++ b/src/Generators/TypeScriptDeclarations.ts
@@ -107,11 +107,15 @@ export class TypeScriptDeclarations extends Generator<TypeScriptDeclarationsOpts
     const { nameTransformer, loose } = this.options;
     const key = quoteKey(nameTransformer!(token.name));
     const typeAnnotation = toTypeAnnotation(token.value, loose || false);
+    const deprecationTag = token.deprecated
+      ? `   *  @deprecated${token.replacement ? ` use \`${nameTransformer!(token.replacement)}\` instead` : ""}`
+      : null;
 
     return [
       `  /**`,
       token.usage && `   *  ${token.usage}`,
       `   *  Type: ${token.type}`,
+      deprecationTag,
       `   */`,
       `  readonly ${key}: ${typeAnnotation};`,
     ]

--- a/src/Generators/TypeScriptDeclarations.ts
+++ b/src/Generators/TypeScriptDeclarations.ts
@@ -6,6 +6,7 @@ import { isFirstClassValue } from "../type-classifiers.js";
 import { getDate } from "../utils.js";
 import type { GeneratorInfo, GeneratorOptions } from "./Generator.js";
 import { Generator } from "./Generator.js";
+import type { JavaScriptModule } from "./JavaScript.js";
 import { quoteKey } from "./value-serializers.js";
 
 /**
@@ -57,6 +58,13 @@ export type TypeScriptDeclarationsOpts = {
    * `type TokenColor = typeof tokens[keyof typeof tokens]`.
    */
   loose?: boolean;
+  /**
+   * Pair the declarations file with a specific runtime module format. When
+   * set to `"cjs"`, emit `.d.cts` instead of `.d.ts` so Node's strict
+   * ESM/CJS resolvers (`moduleResolution: "node16" | "bundler"`) pick up
+   * the declarations alongside the `.cjs` runtime file.
+   */
+  module?: JavaScriptModule;
 } & GeneratorOptions;
 
 /**
@@ -66,7 +74,8 @@ export type TypeScriptDeclarationsOpts = {
  */
 export class TypeScriptDeclarations extends Generator<TypeScriptDeclarationsOpts> {
   constructor(options: Partial<TypeScriptDeclarationsOpts> = {}) {
-    super({ ...defaultOptions, ...options });
+    const ext = options.module === "cjs" ? "d.cts" : "d.ts";
+    super({ ...defaultOptions, ...options, ext });
   }
 
   override describe(): GeneratorInfo {

--- a/src/Generators/multi-file-stress.test.ts
+++ b/src/Generators/multi-file-stress.test.ts
@@ -111,14 +111,11 @@ describe("TypeScript meta option propagation", () => {
     expect(files).toContain("design.d.ts");
   });
 
-  test("module: 'cjs' emits .cjs for JS; declarations stay .d.ts", () => {
+  test("module: 'cjs' emits .cjs for JS and .d.cts for declarations", () => {
     const ts = new TypeScript({ module: "cjs", filename: "design", dateFn: fixedDate });
     const files = ts.filenames();
     expect(files).toContain("design.cjs");
-    // DESIGN QUESTION: when module=cjs, should declarations be .d.cts so
-    // Node's conditional resolution picks them up under `require`? Current
-    // implementation emits `.d.ts` regardless.
-    expect(files).toContain("design.d.ts");
+    expect(files).toContain("design.d.cts");
   });
 
   test("loose: true affects declarations but not JS", () => {

--- a/src/Generators/multi-file-stress.test.ts
+++ b/src/Generators/multi-file-stress.test.ts
@@ -1,0 +1,639 @@
+import { createRequire } from "node:module";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { describe, expect, test } from "bun:test";
+
+import { Teikn } from "../Teikn.js";
+import type { Plugin } from "../Plugins/index.js";
+import type { Token } from "../Token.js";
+import { CssVars } from "./CssVars.js";
+import { Generator } from "./Generator.js";
+import { JavaScript } from "./JavaScript.js";
+import { Json } from "./Json.js";
+import { Scss } from "./Scss.js";
+import { Storybook } from "./Storybook.js";
+import { TypeScript } from "./TypeScript.js";
+import { TypeScriptDeclarations } from "./TypeScriptDeclarations.js";
+
+const tokens: Token[] = [
+  { name: "primary", type: "color", value: "#0066cc" },
+  { name: "sm", type: "spacing", value: "4px" },
+];
+
+const fixedDate = () => "2024-01-01";
+
+// ─── Scenario 1: Duplicate filename across generators ─────────────
+describe("duplicate filename across generators", () => {
+  test("two CssVars with same default filename throw at construction", () => {
+    expect(
+      () =>
+        new Teikn({
+          generators: [new CssVars(), new CssVars()],
+        }),
+    ).toThrow(/Duplicate generator output filenames/);
+  });
+
+  test("CssVars + Scss with the same configured filename + ext throw", () => {
+    // Both share the same filename but DIFFERENT extensions (.css vs .scss)
+    // — so this should NOT collide. Sanity branch.
+    expect(
+      () =>
+        new Teikn({
+          generators: [new CssVars({ filename: "shared" }), new Scss({ filename: "shared" })],
+        }),
+    ).not.toThrow();
+  });
+
+  test("two CssVars with same explicit filename throw", () => {
+    expect(
+      () =>
+        new Teikn({
+          generators: [new CssVars({ filename: "design" }), new CssVars({ filename: "design" })],
+        }),
+    ).toThrow(/Duplicate generator output filenames/);
+  });
+
+  test("error message names the colliding filename", () => {
+    try {
+      new Teikn({ generators: [new CssVars(), new CssVars()] });
+      throw new Error("did not throw");
+    } catch (e) {
+      expect((e as Error).message).toContain("tokens.css");
+    }
+  });
+
+  test("case-insensitive collision (macOS/Windows FS) is caught", () => {
+    expect(
+      () =>
+        new Teikn({
+          generators: [new CssVars({ filename: "Tokens" }), new CssVars({ filename: "tokens" })],
+        }),
+    ).toThrow(/Duplicate/);
+  });
+});
+
+// ─── Scenario 2: Duplicate filename WITHIN a single generator ─────
+describe("duplicate filenames within a single generator", () => {
+  test("generator whose filenames() returns duplicates is NOT currently caught", () => {
+    class LiarGenerator extends Generator {
+      constructor() {
+        super({ ext: "txt", filename: "out" });
+      }
+      generateToken() {
+        return "";
+      }
+      // oxlint-disable-next-line class-methods-use-this
+      combinator() {
+        return "x";
+      }
+      override filenames(): string[] {
+        return ["a.txt", "a.txt"];
+      }
+      override generateFiles(): Map<string, string> {
+        return new Map([["a.txt", "x"]]);
+      }
+    }
+
+    // BUG (suspected, src/Teikn.ts:206-225): the duplicate-filename check
+    // flattens all generators' filenames into one list and reports any
+    // repeat. So an intra-generator dupe IS caught — but the error message
+    // implies cross-generator collision ("Use the `filename` option to
+    // differentiate"), which is misleading when only one generator is at
+    // fault.
+    expect(() => new Teikn({ generators: [new LiarGenerator()] })).toThrow(/Duplicate/);
+  });
+});
+
+// ─── Scenario 3: TypeScript meta option propagation ───────────────
+describe("TypeScript meta option propagation", () => {
+  test("filename propagates to both .mjs and .d.ts outputs", () => {
+    const ts = new TypeScript({ filename: "design", dateFn: fixedDate });
+    const files = ts.filenames();
+    expect(files).toContain("design.mjs");
+    expect(files).toContain("design.d.ts");
+  });
+
+  test("module: 'cjs' emits .cjs for JS; declarations stay .d.ts", () => {
+    const ts = new TypeScript({ module: "cjs", filename: "design", dateFn: fixedDate });
+    const files = ts.filenames();
+    expect(files).toContain("design.cjs");
+    // DESIGN QUESTION: when module=cjs, should declarations be .d.cts so
+    // Node's conditional resolution picks them up under `require`? Current
+    // implementation emits `.d.ts` regardless.
+    expect(files).toContain("design.d.ts");
+  });
+
+  test("loose: true affects declarations but not JS", () => {
+    const out = new TypeScript({
+      loose: true,
+      dateFn: fixedDate,
+      filename: "t",
+    }).generateFiles(tokens);
+    const dts = out.get("t.d.ts")!;
+    const mjs = out.get("t.mjs")!;
+    expect(dts).toMatch(/:\s*string;/); // widened
+    expect(dts).not.toContain('"#0066cc"');
+    // JS unaffected — still emits the literal value
+    expect(mjs).toContain("'#0066cc'");
+  });
+
+  test("nameTransformer propagates to both", () => {
+    const upper = (n: string) => n.toUpperCase();
+    const out = new TypeScript({
+      nameTransformer: upper,
+      dateFn: fixedDate,
+      filename: "t",
+    }).generateFiles(tokens);
+    expect(out.get("t.mjs")).toContain("PRIMARY");
+    expect(out.get("t.d.ts")).toContain("PRIMARY");
+  });
+
+  test("groups propagates to both", () => {
+    const out = new TypeScript({
+      groups: true,
+      dateFn: fixedDate,
+      filename: "t",
+    }).generateFiles(tokens);
+    expect(out.get("t.mjs")).toMatch(/export const color\s*=/);
+    expect(out.get("t.d.ts")).toMatch(/export declare const color:/);
+  });
+
+  test("version propagates to both", () => {
+    const out = new TypeScript({
+      version: "stress-test",
+      dateFn: fixedDate,
+      filename: "t",
+    }).generateFiles(tokens);
+    expect(out.get("t.mjs")).toContain("stress-test");
+    expect(out.get("t.d.ts")).toContain("stress-test");
+  });
+
+  test("dateFn propagates to both", () => {
+    const out = new TypeScript({
+      dateFn: () => "DATESTAMP",
+      filename: "t",
+    }).generateFiles(tokens);
+    expect(out.get("t.mjs")).toContain("DATESTAMP");
+    expect(out.get("t.d.ts")).toContain("DATESTAMP");
+  });
+
+  test("explicit ext is rejected on TypeScript meta", () => {
+    // @ts-expect-error — ext is intentionally not in TypeScriptOpts surface
+    expect(() => new TypeScript({ ext: "ts" })).toThrow(/does not accept an `ext`/);
+  });
+});
+
+// ─── Scenario 4: TS meta + other generator filename collision ─────
+describe("TypeScript meta + sibling collision", () => {
+  test("Json sharing TS meta's runtime filename should collide", () => {
+    // TS meta emits "design.mjs" + "design.d.ts"; a Json generator
+    // configured to "design.mjs" would collide on the .mjs slot.
+    expect(
+      () =>
+        new Teikn({
+          generators: [
+            new TypeScript({ filename: "design", dateFn: fixedDate }),
+            // Json's ext is .json — base "design.mjs" produces "design.mjs.json".
+            // To force a real collision we need the same final filename.
+            new Json({ filename: "design.mjs" }),
+          ],
+        }),
+      // BUG (suspected): Generator.file appends `.${ext}` unless the filename
+      // already ends in `.${ext}`. So `Json({filename:"design.mjs"})` yields
+      // `design.mjs.json` and does NOT collide. There's no way to ergonomically
+      // force a same-named .json + .mjs check; harness-only collision is the
+      // realistic case (same ext, same base).
+    ).not.toThrow();
+  });
+
+  test("TS meta + JavaScript using same filename collides on .mjs", () => {
+    expect(
+      () =>
+        new Teikn({
+          generators: [
+            new TypeScript({ filename: "design", dateFn: fixedDate }),
+            new JavaScript({ filename: "design" }),
+          ],
+        }),
+    ).toThrow(/Duplicate/);
+  });
+
+  test("TS meta + TypeScriptDeclarations using same filename collides on .d.ts", () => {
+    expect(
+      () =>
+        new Teikn({
+          generators: [
+            new TypeScript({ filename: "design", dateFn: fixedDate }),
+            new TypeScriptDeclarations({ filename: "design" }),
+          ],
+        }),
+    ).toThrow(/Duplicate/);
+  });
+});
+
+// ─── Scenario 5: Empty token set ──────────────────────────────────
+describe("empty token set", () => {
+  test("CssVars handles empty tokens", () => {
+    const out = new CssVars({ dateFn: fixedDate }).generateFiles([]);
+    expect(out.size).toBe(1);
+    expect(out.get("tokens.css")).toBeDefined();
+  });
+
+  test("JavaScript handles empty tokens", () => {
+    const out = new JavaScript({ dateFn: fixedDate }).generateFiles([]);
+    expect(out.size).toBe(1);
+    const content = out.get("tokens.mjs")!;
+    expect(content).toContain("export const tokens = {");
+  });
+
+  test("Storybook handles empty tokens (with importPath)", () => {
+    // Storybook needs a sibling JS generator OR explicit importPath.
+    const sb = new Storybook({ importPath: "./tokens", dateFn: fixedDate });
+    const out = sb.generateFiles([]);
+    expect(out.size).toBe(1);
+    expect(out.get("tokens.stories.tsx")).toBeDefined();
+  });
+
+  test("Teikn.generateToStrings with no tokens returns expected file set", () => {
+    const teikn = new Teikn({
+      generators: [new CssVars({ dateFn: fixedDate })],
+      validate: false,
+    });
+    const result = teikn.generateToStrings([]);
+    expect([...result.keys()]).toEqual(["tokens.css"]);
+  });
+});
+
+// ─── Scenario 6: Deterministic iteration order ────────────────────
+describe("generateToStrings order is deterministic", () => {
+  test("registration order is preserved in output Map", () => {
+    const teikn = new Teikn({
+      generators: [
+        new Json({ filename: "a" }),
+        new CssVars({ filename: "b", dateFn: fixedDate }),
+        new Scss({ filename: "c", dateFn: fixedDate }),
+      ],
+      validate: false,
+    });
+    const keys = [...teikn.generateToStrings(tokens).keys()];
+    expect(keys).toEqual(["a.json", "b.css", "c.scss"]);
+  });
+
+  test("two consecutive runs produce identical key order", () => {
+    const teikn = new Teikn({
+      generators: [new Json({ filename: "a" }), new CssVars({ filename: "b", dateFn: fixedDate })],
+      validate: false,
+    });
+    const k1 = [...teikn.generateToStrings(tokens).keys()];
+    const k2 = [...teikn.generateToStrings(tokens).keys()];
+    expect(k1).toEqual(k2);
+  });
+});
+
+// ─── Scenario 7: Custom generator collides with built-in ──────────
+describe("custom generator collision with built-in", () => {
+  test("a custom Generator that outputs tokens.css collides with CssVars", () => {
+    class CustomCss extends Generator {
+      constructor() {
+        super({ ext: "css", filename: "tokens" });
+      }
+      generateToken() {
+        return "";
+      }
+      // oxlint-disable-next-line class-methods-use-this
+      combinator() {
+        return "/* custom */";
+      }
+    }
+    expect(
+      () =>
+        new Teikn({
+          generators: [new CssVars(), new CustomCss()],
+        }),
+    ).toThrow(/Duplicate/);
+  });
+});
+
+// ─── Scenario 8: Lying generator (more files than declared) ───────
+describe("generator that emits more files than declared", () => {
+  test("extra files in generateFiles leak through (contract not enforced)", () => {
+    class OverDeliver extends Generator {
+      constructor() {
+        super({ ext: "txt", filename: "a" });
+      }
+      generateToken() {
+        return "";
+      }
+      // oxlint-disable-next-line class-methods-use-this
+      combinator() {
+        return "x";
+      }
+      override filenames(): string[] {
+        return ["a.txt"];
+      }
+      override generateFiles(): Map<string, string> {
+        return new Map([
+          ["a.txt", "declared content"],
+          ["sneaky.txt", "undeclared content"],
+        ]);
+      }
+    }
+
+    const teikn = new Teikn({ generators: [new OverDeliver()], validate: false });
+    const out = teikn.generateToStrings([]);
+    // BUG / DESIGN QUESTION (src/Teikn.ts:296-301): undeclared files leak
+    // through into the output Map. This breaks the duplicate-detection
+    // invariant — a generator could secretly emit "tokens.css" at runtime
+    // and clobber CssVars' output without being caught at construction.
+    expect(out.has("sneaky.txt")).toBe(true);
+    expect(out.get("sneaky.txt")).toBe("undeclared content");
+  });
+
+  test("undeclared file can silently clobber another generator's output", () => {
+    class Squatter extends Generator {
+      constructor() {
+        super({ ext: "txt", filename: "harmless" });
+      }
+      generateToken() {
+        return "";
+      }
+      // oxlint-disable-next-line class-methods-use-this
+      combinator() {
+        return "";
+      }
+      override filenames(): string[] {
+        return ["harmless.txt"];
+      }
+      override generateFiles(): Map<string, string> {
+        return new Map([
+          ["harmless.txt", "ok"],
+          ["tokens.css", "/* CLOBBERED */"],
+        ]);
+      }
+    }
+
+    // CssVars is registered first; Squatter overwrites it at merge time.
+    const teikn = new Teikn({
+      generators: [new CssVars({ dateFn: fixedDate }), new Squatter()],
+      validate: false,
+    });
+    const out = teikn.generateToStrings(tokens);
+    // BUG: the duplicate check at construction missed this because Squatter
+    // only declared "harmless.txt". The merge loop just overwrites.
+    expect(out.get("tokens.css")).toBe("/* CLOBBERED */");
+  });
+});
+
+// ─── Scenario 9: Under-delivering generator ───────────────────────
+describe("generator that declares more files than it emits", () => {
+  test("missing declared file is NOT surfaced (silent omission)", () => {
+    class UnderDeliver extends Generator {
+      constructor() {
+        super({ ext: "txt", filename: "a" });
+      }
+      generateToken() {
+        return "";
+      }
+      // oxlint-disable-next-line class-methods-use-this
+      combinator() {
+        return "";
+      }
+      override filenames(): string[] {
+        return ["a.txt", "b.txt"];
+      }
+      override generateFiles(): Map<string, string> {
+        return new Map([["a.txt", "x"]]);
+      }
+    }
+
+    const teikn = new Teikn({ generators: [new UnderDeliver()], validate: false });
+    const out = teikn.generateToStrings([]);
+    // BUG / DESIGN QUESTION: declared "b.txt" is missing from output but
+    // no error is raised. Downstream consumers expecting that file (e.g.
+    // a Storybook stories file importing it) would fail at runtime.
+    expect(out.has("a.txt")).toBe(true);
+    expect(out.has("b.txt")).toBe(false);
+  });
+});
+
+// ─── Scenario 10: ESM resolution check ────────────────────────────
+describe("emitted ESM is loadable by Node's import", () => {
+  test("JavaScript({module:'esm'}) output is valid ESM with named export", async () => {
+    const teikn = new Teikn({
+      generators: [new JavaScript({ filename: "tokens-esm", dateFn: fixedDate })],
+      validate: false,
+    });
+    const result = teikn.generateToStrings(tokens);
+    const content = result.get("tokens-esm.mjs")!;
+
+    const tmp = path.join(os.tmpdir(), `teikn-esm-${Date.now()}-${Math.random()}.mjs`);
+    fs.writeFileSync(tmp, content);
+    try {
+      const mod = await import(pathToFileURL(tmp).href);
+      expect(mod.tokens).toBeDefined();
+      // type-prefixed names: color-primary → camelCase → "colorPrimary"
+      expect(typeof mod.tokens).toBe("object");
+      expect(mod.default).toBe(mod.tokens);
+    } finally {
+      fs.unlinkSync(tmp);
+    }
+  });
+});
+
+// ─── Scenario 11: CJS resolution check ────────────────────────────
+describe("emitted CJS is loadable by Node's require", () => {
+  test("JavaScript({module:'cjs'}) output is valid CJS", () => {
+    const teikn = new Teikn({
+      generators: [new JavaScript({ module: "cjs", filename: "tokens-cjs", dateFn: fixedDate })],
+      validate: false,
+    });
+    const result = teikn.generateToStrings(tokens);
+    const content = result.get("tokens-cjs.cjs")!;
+
+    const tmp = path.join(os.tmpdir(), `teikn-cjs-${Date.now()}-${Math.random()}.cjs`);
+    fs.writeFileSync(tmp, content);
+    try {
+      const req = createRequire(import.meta.url);
+      // Bust the cache
+      delete req.cache?.[tmp];
+      const mod = req(tmp);
+      expect(mod.tokens).toBeDefined();
+      expect(mod.default).toBe(mod.tokens);
+    } finally {
+      fs.unlinkSync(tmp);
+    }
+  });
+});
+
+// ─── Scenario 12: Filename with directory separator ───────────────
+describe("filename with directory separator", () => {
+  test("subdir/foo passes through to Map key as-is", () => {
+    const out = new CssVars({ filename: "subdir/tokens", dateFn: fixedDate }).generateFiles(tokens);
+    const keys = [...out.keys()];
+    // DESIGN QUESTION: should the generator reject paths with separators
+    // (filenames are conceptually file *names*) or treat them as relative
+    // paths? Today they pass through, and Teikn.transform() relies on
+    // ensureDirectory at outDir level only — so writing "subdir/tokens.css"
+    // would fail unless the subdir already exists.
+    expect(keys).toEqual(["subdir/tokens.css"]);
+  });
+
+  test("filename with .. is not sanitized", () => {
+    const out = new CssVars({ filename: "../escape", dateFn: fixedDate }).generateFiles(tokens);
+    // DESIGN QUESTION: this writes outside outDir on transform(). Likely
+    // a real issue if filenames ever come from untrusted config.
+    expect([...out.keys()]).toEqual(["../escape.css"]);
+  });
+});
+
+// ─── Scenario 13: Filename extension handling ─────────────────────
+describe("filename extension handling", () => {
+  test("user passes filename that already ends in .css → no double extension", () => {
+    const out = new CssVars({ filename: "tokens.css", dateFn: fixedDate }).generateFiles(tokens);
+    expect([...out.keys()]).toEqual(["tokens.css"]);
+  });
+
+  test("user passes filename with WRONG ext (.txt) — gets appended .css", () => {
+    const out = new CssVars({ filename: "tokens.txt", dateFn: fixedDate }).generateFiles(tokens);
+    // DESIGN QUESTION (src/Generators/Generator.ts:152-160): the generator
+    // appends its own ext only when the filename doesn't already end in
+    // that ext. So "tokens.txt" → "tokens.txt.css". Probably surprising —
+    // a user who explicitly typed `.txt` likely wanted to override the
+    // extension, OR they should be warned.
+    expect([...out.keys()]).toEqual(["tokens.txt.css"]);
+  });
+
+  test("filename with no extension gets ext appended", () => {
+    const out = new CssVars({ filename: "tokens", dateFn: fixedDate }).generateFiles(tokens);
+    expect([...out.keys()]).toEqual(["tokens.css"]);
+  });
+
+  test("JavaScript filename containing .mjs is preserved (no double)", () => {
+    const out = new JavaScript({ filename: "tokens.mjs", dateFn: fixedDate }).generateFiles(tokens);
+    expect([...out.keys()]).toEqual(["tokens.mjs"]);
+  });
+
+  test("JavaScript({module:'cjs'}) with filename 'tokens.mjs' → tokens.mjs.cjs", () => {
+    const out = new JavaScript({
+      module: "cjs",
+      filename: "tokens.mjs",
+      dateFn: fixedDate,
+    }).generateFiles(tokens);
+    // BUG / DESIGN QUESTION: a user-provided `.mjs` filename when
+    // module is "cjs" yields the awkward "tokens.mjs.cjs". Suggests
+    // the generator should either warn or strip a known-incorrect ext.
+    expect([...out.keys()]).toEqual(["tokens.mjs.cjs"]);
+  });
+});
+
+// ─── Scenario 14: Storybook .tsx vs .jsx output validity ──────────
+describe("Storybook output sanity (regex-level)", () => {
+  const sanityCheck = (src: string) => {
+    // imports
+    expect(src).toMatch(/import\s+\{/);
+    // story export
+    expect(src).toMatch(/export\s+(default|const)/);
+    // balanced braces — basic
+    const opens = (src.match(/\{/g) || []).length;
+    const closes = (src.match(/\}/g) || []).length;
+    expect(opens).toBe(closes);
+    // balanced angle brackets in JSX-ish form (loose)
+    // Just look for at least one <Tag and a closing </ or self-close
+    expect(src).toMatch(/<[A-Z]\w*/);
+  };
+
+  test(".stories.tsx output has TypeScript-flavored imports", () => {
+    const teikn = new Teikn({
+      generators: [
+        new JavaScript({ filename: "design", dateFn: fixedDate }),
+        new Storybook({ dateFn: fixedDate }),
+      ],
+      validate: false,
+    });
+    const out = teikn.generateToStrings(tokens);
+    const sb = out.get("tokens.stories.tsx")!;
+    expect(sb).toContain("import type { Meta, StoryObj }");
+    sanityCheck(sb);
+  });
+
+  test(".stories.jsx output omits type imports", () => {
+    const teikn = new Teikn({
+      generators: [
+        new JavaScript({ filename: "design", dateFn: fixedDate }),
+        new Storybook({ filename: "tokens", dateFn: fixedDate, ext: "stories.jsx" }),
+      ],
+      validate: false,
+    });
+    const out = teikn.generateToStrings(tokens);
+    const sb = out.get("tokens.stories.jsx")!;
+    expect(sb).not.toContain("import type");
+    expect(sb).not.toMatch(/:\s*Meta</);
+    sanityCheck(sb);
+  });
+});
+
+// ─── Scenario 15: Repeat runs are identical ───────────────────────
+describe("idempotence of generateToStrings", () => {
+  test("calling twice produces identical Maps", () => {
+    const teikn = new Teikn({
+      generators: [
+        new CssVars({ dateFn: fixedDate }),
+        new JavaScript({ filename: "tokens-rt", dateFn: fixedDate }),
+      ],
+      validate: false,
+    });
+    const a = teikn.generateToStrings(tokens);
+    const b = teikn.generateToStrings(tokens);
+    expect([...a.entries()]).toEqual([...b.entries()]);
+  });
+});
+
+// ─── Scenario 16: Mutating tokens between runs ────────────────────
+describe("token mutation between runs", () => {
+  test("mutating the input array between runs IS reflected (no caching)", () => {
+    const local: Token[] = [{ name: "primary", type: "color", value: "#000000" }];
+    const teikn = new Teikn({
+      generators: [new CssVars({ dateFn: fixedDate })],
+      validate: false,
+    });
+    const first = teikn.generateToStrings(local).get("tokens.css")!;
+    expect(first).toContain("#000000");
+
+    // Replace contents in-place (the user-controlled mutation case).
+    local[0] = { name: "primary", type: "color", value: "#ffffff" };
+    const second = teikn.generateToStrings(local).get("tokens.css")!;
+    expect(second).toContain("#ffffff");
+    expect(second).not.toContain("#000000");
+  });
+
+  test("mutating a token object in place is reflected on next run", () => {
+    const t: Token = { name: "primary", type: "color", value: "#000000" };
+    const local: Token[] = [t];
+    const teikn = new Teikn({
+      generators: [new CssVars({ dateFn: fixedDate })],
+      validate: false,
+    });
+    const a = teikn.generateToStrings(local).get("tokens.css")!;
+    // mutate the token directly
+    (t as { value: string }).value = "#abcabc";
+    const b = teikn.generateToStrings(local).get("tokens.css")!;
+    expect(a).not.toBe(b);
+    expect(b).toContain("#abcabc");
+  });
+});
+
+// ─── Bonus: empty plugins array path ──────────────────────────────
+describe("Plugin pipeline edge cases", () => {
+  test("generators accept undefined plugins argument", () => {
+    expect(() => new CssVars({ dateFn: fixedDate }).generateFiles(tokens)).not.toThrow();
+  });
+
+  test("generator receives empty plugins[] without crashing", () => {
+    const plugins: Plugin[] = [];
+    expect(() =>
+      new JavaScript({ dateFn: fixedDate }).generateFiles(tokens, plugins),
+    ).not.toThrow();
+  });
+});

--- a/src/Generators/multi-file-stress.test.ts
+++ b/src/Generators/multi-file-stress.test.ts
@@ -465,22 +465,22 @@ describe("emitted CJS is loadable by Node's require", () => {
 
 // ─── Scenario 12: Filename with directory separator ───────────────
 describe("filename with directory separator", () => {
-  test("subdir/foo passes through to Map key as-is", () => {
-    const out = new CssVars({ filename: "subdir/tokens", dateFn: fixedDate }).generateFiles(tokens);
-    const keys = [...out.keys()];
-    // DESIGN QUESTION: should the generator reject paths with separators
-    // (filenames are conceptually file *names*) or treat them as relative
-    // paths? Today they pass through, and Teikn.transform() relies on
-    // ensureDirectory at outDir level only — so writing "subdir/tokens.css"
-    // would fail unless the subdir already exists.
-    expect(keys).toEqual(["subdir/tokens.css"]);
+  test("filename containing / is rejected at construction", () => {
+    expect(() => new CssVars({ filename: "subdir/tokens", dateFn: fixedDate })).toThrow(
+      /path separators/,
+    );
   });
 
-  test("filename with .. is not sanitized", () => {
-    const out = new CssVars({ filename: "../escape", dateFn: fixedDate }).generateFiles(tokens);
-    // DESIGN QUESTION: this writes outside outDir on transform(). Likely
-    // a real issue if filenames ever come from untrusted config.
-    expect([...out.keys()]).toEqual(["../escape.css"]);
+  test("filename containing .. is rejected at construction", () => {
+    expect(() => new CssVars({ filename: "../escape", dateFn: fixedDate })).toThrow(
+      /path separators|\.\./,
+    );
+  });
+
+  test("filename containing backslash is rejected at construction", () => {
+    expect(() => new CssVars({ filename: "subdir\\tokens", dateFn: fixedDate })).toThrow(
+      /path separators/,
+    );
   });
 });
 

--- a/src/Generators/multi-file-stress.test.ts
+++ b/src/Generators/multi-file-stress.test.ts
@@ -338,13 +338,9 @@ describe("generator that emits more files than declared", () => {
     }
 
     const teikn = new Teikn({ generators: [new OverDeliver()], validate: false });
-    const out = teikn.generateToStrings([]);
-    // BUG / DESIGN QUESTION (src/Teikn.ts:296-301): undeclared files leak
-    // through into the output Map. This breaks the duplicate-detection
-    // invariant — a generator could secretly emit "tokens.css" at runtime
-    // and clobber CssVars' output without being caught at construction.
-    expect(out.has("sneaky.txt")).toBe(true);
-    expect(out.get("sneaky.txt")).toBe("undeclared content");
+    expect(() => teikn.generateToStrings([])).toThrow(
+      /OverDeliver.*did not declare.*sneaky\.txt/,
+    );
   });
 
   test("undeclared file can silently clobber another generator's output", () => {
@@ -370,15 +366,15 @@ describe("generator that emits more files than declared", () => {
       }
     }
 
-    // CssVars is registered first; Squatter overwrites it at merge time.
+    // CssVars is registered first; Squatter previously overwrote it at merge
+    // time. The hard contract now catches this at generateToStrings time.
     const teikn = new Teikn({
       generators: [new CssVars({ dateFn: fixedDate }), new Squatter()],
       validate: false,
     });
-    const out = teikn.generateToStrings(tokens);
-    // BUG: the duplicate check at construction missed this because Squatter
-    // only declared "harmless.txt". The merge loop just overwrites.
-    expect(out.get("tokens.css")).toBe("/* CLOBBERED */");
+    expect(() => teikn.generateToStrings(tokens)).toThrow(
+      /Squatter.*did not declare.*tokens\.css/,
+    );
   });
 });
 
@@ -405,12 +401,7 @@ describe("generator that declares more files than it emits", () => {
     }
 
     const teikn = new Teikn({ generators: [new UnderDeliver()], validate: false });
-    const out = teikn.generateToStrings([]);
-    // BUG / DESIGN QUESTION: declared "b.txt" is missing from output but
-    // no error is raised. Downstream consumers expecting that file (e.g.
-    // a Storybook stories file importing it) would fail at runtime.
-    expect(out.has("a.txt")).toBe(true);
-    expect(out.has("b.txt")).toBe(false);
+    expect(() => teikn.generateToStrings([])).toThrow(/UnderDeliver.*declared.*b\.txt/);
   });
 });
 

--- a/src/Generators/multi-file-stress.test.ts
+++ b/src/Generators/multi-file-stress.test.ts
@@ -96,13 +96,9 @@ describe("duplicate filenames within a single generator", () => {
       }
     }
 
-    // BUG (suspected, src/Teikn.ts:206-225): the duplicate-filename check
-    // flattens all generators' filenames into one list and reports any
-    // repeat. So an intra-generator dupe IS caught — but the error message
-    // implies cross-generator collision ("Use the `filename` option to
-    // differentiate"), which is misleading when only one generator is at
-    // fault.
-    expect(() => new Teikn({ generators: [new LiarGenerator()] })).toThrow(/Duplicate/);
+    expect(() => new Teikn({ generators: [new LiarGenerator()] })).toThrow(
+      /LiarGenerator.*duplicate output filenames/,
+    );
   });
 });
 

--- a/src/Generators/multi-file-stress.test.ts
+++ b/src/Generators/multi-file-stress.test.ts
@@ -335,9 +335,7 @@ describe("generator that emits more files than declared", () => {
     }
 
     const teikn = new Teikn({ generators: [new OverDeliver()], validate: false });
-    expect(() => teikn.generateToStrings([])).toThrow(
-      /OverDeliver.*did not declare.*sneaky\.txt/,
-    );
+    expect(() => teikn.generateToStrings([])).toThrow(/OverDeliver.*did not declare.*sneaky\.txt/);
   });
 
   test("undeclared file can silently clobber another generator's output", () => {
@@ -369,9 +367,7 @@ describe("generator that emits more files than declared", () => {
       generators: [new CssVars({ dateFn: fixedDate }), new Squatter()],
       validate: false,
     });
-    expect(() => teikn.generateToStrings(tokens)).toThrow(
-      /Squatter.*did not declare.*tokens\.css/,
-    );
+    expect(() => teikn.generateToStrings(tokens)).toThrow(/Squatter.*did not declare.*tokens\.css/);
   });
 });
 

--- a/src/Plugins/DeprecationPlugin.ts
+++ b/src/Plugins/DeprecationPlugin.ts
@@ -27,6 +27,6 @@ export class DeprecationPlugin extends Plugin<DeprecationPluginOptions> {
       deprecated: true,
       ...(replacement ? { replacement } : {}),
       usage,
-    } as Token & { deprecated: boolean; replacement?: string };
+    };
   }
 }

--- a/src/Plugins/Plugin.ts
+++ b/src/Plugins/Plugin.ts
@@ -67,6 +67,11 @@ export const sortPlugins = (plugins: Plugin[]): Plugin[] => {
       const depPlugin = nameMap.get(dep);
       if (depPlugin) {
         visit(depPlugin);
+      } else {
+        console.error(
+          `Plugin \`${name}\` declares \`runAfter: ["${dep}"]\`, but no plugin named \`${dep}\` is registered. ` +
+            `The ordering hint is being ignored. Check for a typo or remove the entry.`,
+        );
       }
     }
     visiting.delete(name);

--- a/src/Plugins/plugin-stress.test.ts
+++ b/src/Plugins/plugin-stress.test.ts
@@ -72,20 +72,27 @@ describe("Scenario 1 — cycle in runAfter", () => {
 // ─── Scenario 2: unregistered runAfter target ────────────────
 
 describe("Scenario 2 — runAfter references unregistered plugin", () => {
-  test("missing runAfter targets are silently ignored", () => {
-    // DESIGN QUESTION: is silent skip the right behavior?
-    // A typo in runAfter goes undetected — e.g. "ColroTransformPlugin"
-    // (sic) would not warn, the plugin runs first and bug surfaces
-    // far downstream.
+  test("missing runAfter targets log to stderr and continue", () => {
     class Dependent extends Plugin {
       tokenType: RegExp = /.*/;
       outputType: RegExp = /.*/;
       override readonly runAfter: string[] = ["NotARealPlugin"];
     }
     const d = new Dependent();
-    const result = sortPlugins([d]);
-    expect(result).toEqual([d]);
-    // Observed: no warning, no throw. Document for design decision.
+    const original = console.error;
+    const messages: string[] = [];
+    console.error = (msg: string) => {
+      messages.push(msg);
+    };
+    try {
+      const result = sortPlugins([d]);
+      expect(result).toEqual([d]);
+    } finally {
+      console.error = original;
+    }
+    expect(messages.length).toBe(1);
+    expect(messages[0]).toMatch(/Dependent/);
+    expect(messages[0]).toMatch(/NotARealPlugin/);
   });
 });
 

--- a/src/Plugins/plugin-stress.test.ts
+++ b/src/Plugins/plugin-stress.test.ts
@@ -1,0 +1,651 @@
+import { describe, expect, test } from "bun:test";
+
+import type { Token } from "../Token.js";
+import { Color } from "../TokenTypes/Color/index.js";
+import { BoxShadow } from "../TokenTypes/BoxShadow.js";
+import { CssVars } from "../Generators/CssVars.js";
+import { Scss } from "../Generators/Scss.js";
+import { ScssVars } from "../Generators/ScssVars.js";
+import { JavaScript } from "../Generators/JavaScript.js";
+import { Json } from "../Generators/Json.js";
+import { Teikn } from "../Teikn.js";
+import { Plugin, sortPlugins } from "./Plugin.js";
+import { AlphaMultiplyPlugin } from "./AlphaMultiplyPlugin.js";
+import { ClampPlugin } from "./ClampPlugin.js";
+import { ColorTransformPlugin } from "./ColorTransformPlugin.js";
+import { ContrastValidatorPlugin } from "./ContrastValidatorPlugin.js";
+import { DeprecationPlugin } from "./DeprecationPlugin.js";
+import { NameConventionPlugin } from "./NameConventionPlugin.js";
+import { PrefixTypePlugin } from "./PrefixTypePlugin.js";
+import { RemUnitPlugin } from "./RemUnitPlugin.js";
+import { ScssQuoteValuePlugin } from "./ScssQuoteValuePlugin.js";
+import { testOpts } from "../fixtures/testOpts.js";
+
+const opts = testOpts;
+
+// ─── Scenario 1: cycle in runAfter ───────────────────────────
+
+describe("Scenario 1 — cycle in runAfter", () => {
+  test("throws clear error on direct A↔B cycle", () => {
+    class CycA extends Plugin {
+      tokenType: RegExp = /.*/;
+      outputType: RegExp = /.*/;
+      override readonly runAfter: string[] = ["CycB"];
+    }
+    class CycB extends Plugin {
+      tokenType: RegExp = /.*/;
+      outputType: RegExp = /.*/;
+      override readonly runAfter: string[] = ["CycA"];
+    }
+    expect(() => sortPlugins([new CycA(), new CycB()])).toThrow(/cycle/i);
+  });
+
+  test("throws on 3-plugin cycle (A→B→C→A)", () => {
+    class A3 extends Plugin {
+      tokenType: RegExp = /.*/;
+      outputType: RegExp = /.*/;
+      override readonly runAfter: string[] = ["C3"];
+    }
+    class B3 extends Plugin {
+      tokenType: RegExp = /.*/;
+      outputType: RegExp = /.*/;
+      override readonly runAfter: string[] = ["A3"];
+    }
+    class C3 extends Plugin {
+      tokenType: RegExp = /.*/;
+      outputType: RegExp = /.*/;
+      override readonly runAfter: string[] = ["B3"];
+    }
+    expect(() => sortPlugins([new A3(), new B3(), new C3()])).toThrow(/cycle/i);
+  });
+
+  test("throws on self-cycle (A runAfter A)", () => {
+    class Self extends Plugin {
+      tokenType: RegExp = /.*/;
+      outputType: RegExp = /.*/;
+      override readonly runAfter: string[] = ["Self"];
+    }
+    expect(() => sortPlugins([new Self()])).toThrow(/cycle/i);
+  });
+});
+
+// ─── Scenario 2: unregistered runAfter target ────────────────
+
+describe("Scenario 2 — runAfter references unregistered plugin", () => {
+  test("missing runAfter targets are silently ignored", () => {
+    // DESIGN QUESTION: is silent skip the right behavior?
+    // A typo in runAfter goes undetected — e.g. "ColroTransformPlugin"
+    // (sic) would not warn, the plugin runs first and bug surfaces
+    // far downstream.
+    class Dependent extends Plugin {
+      tokenType: RegExp = /.*/;
+      outputType: RegExp = /.*/;
+      override readonly runAfter: string[] = ["NotARealPlugin"];
+    }
+    const d = new Dependent();
+    const result = sortPlugins([d]);
+    expect(result).toEqual([d]);
+    // Observed: no warning, no throw. Document for design decision.
+  });
+});
+
+// ─── Scenario 3: duplicate plugin instances ──────────────────
+
+describe("Scenario 3 — duplicate plugin instances", () => {
+  test("two instances of same class throw", () => {
+    expect(() =>
+      sortPlugins([
+        new NameConventionPlugin({ convention: "camelCase" }),
+        new NameConventionPlugin({ convention: "kebab-case" }),
+      ]),
+    ).toThrow(/duplicate plugin instance/i);
+  });
+});
+
+// ─── Scenario 4: order stability ─────────────────────────────
+
+describe("Scenario 4 — order stability", () => {
+  test("same input → same output across repeated sorts", () => {
+    const make = (): Plugin[] => [
+      new RemUnitPlugin({ base: 16 }),
+      new ColorTransformPlugin({ type: "rgba" }),
+      new AlphaMultiplyPlugin({ background: "#fff" }),
+      new ScssQuoteValuePlugin(),
+    ];
+    const a = sortPlugins(make()).map((p) => p.constructor.name);
+    const b = sortPlugins(make()).map((p) => p.constructor.name);
+    const c = sortPlugins(make()).map((p) => p.constructor.name);
+    expect(a).toEqual(b);
+    expect(b).toEqual(c);
+  });
+
+  test("AlphaMultiply always precedes ColorTransform", () => {
+    const ord1 = sortPlugins([
+      new AlphaMultiplyPlugin({ background: "#fff" }),
+      new ColorTransformPlugin({ type: "rgba" }),
+    ]).map((p) => p.constructor.name);
+    const ord2 = sortPlugins([
+      new ColorTransformPlugin({ type: "rgba" }),
+      new AlphaMultiplyPlugin({ background: "#fff" }),
+    ]).map((p) => p.constructor.name);
+    expect(ord1.indexOf("AlphaMultiplyPlugin")).toBeLessThan(ord1.indexOf("ColorTransformPlugin"));
+    expect(ord2.indexOf("AlphaMultiplyPlugin")).toBeLessThan(ord2.indexOf("ColorTransformPlugin"));
+  });
+});
+
+// ─── Scenario 5: NameConvention + (StripTypePrefix as proxy) ─
+
+describe("Scenario 5 — NameConventionPlugin ordering normalization", () => {
+  // PrefixTypePlugin is rejected by Teikn (type-prefixing is built-in
+  // since alpha.x). Use the sortPlugins API directly to verify the
+  // runAfter contract: NameConventionPlugin declares runAfter:
+  // ["PrefixTypePlugin", "StripTypePrefixPlugin"].
+  test("NameConvention sorts after PrefixType regardless of input order", () => {
+    const a = sortPlugins([
+      new NameConventionPlugin({ convention: "camelCase" }),
+      new PrefixTypePlugin(),
+    ]).map((p) => p.constructor.name);
+    const b = sortPlugins([
+      new PrefixTypePlugin(),
+      new NameConventionPlugin({ convention: "camelCase" }),
+    ]).map((p) => p.constructor.name);
+    expect(a).toEqual(b);
+    expect(a[0]).toBe("PrefixTypePlugin");
+    expect(a[1]).toBe("NameConventionPlugin");
+  });
+
+  test("Generator-level PrefixTypePlugin + NameConvention produces stable output", () => {
+    // Generator.generate() applies sortPlugins, so order at call site is irrelevant.
+    const tokens: Token[] = [{ name: "primary", type: "color", value: "#fff" }];
+    const ord1 = new Json().generate(tokens, [
+      new NameConventionPlugin({ convention: "camelCase" }),
+      new PrefixTypePlugin(),
+    ]);
+    const ord2 = new Json().generate(tokens, [
+      new PrefixTypePlugin(),
+      new NameConventionPlugin({ convention: "camelCase" }),
+    ]);
+    expect(ord1).toBe(ord2);
+    // PrefixType produces "colorPrimary", then NameConvention(camelCase) → "colorPrimary"
+    expect(JSON.parse(ord1).colorPrimary).toBeDefined();
+  });
+});
+
+// ─── Scenario 6 — refs in composite values + NameConvention ──
+
+describe("Scenario 6 — NameConvention renames refs in composite values", () => {
+  // Full Teikn pipeline: resolveReferences runs BEFORE plugins, so by the
+  // time NameConventionPlugin sees tokens, refs are inlined values.
+  // The actual surfaced concern is: does the generated output still link
+  // ref tokens after the name conv changes? Test by writing tokens with
+  // a string-ref BoxShadow.color and verifying generated output is sane.
+  test("CssVars: BoxShadow with ref color survives rename", () => {
+    const tokens: Token[] = [
+      { name: "color-primary", type: "color", value: "#abcdef" },
+      {
+        name: "shadow-card",
+        type: "shadow",
+        value: {
+          color: "{color-primary}",
+          offsetX: "0",
+          offsetY: "2px",
+          blur: "4px",
+          spread: "0",
+        },
+      },
+    ];
+    const teikn = new Teikn({
+      generators: [new CssVars(opts)],
+      plugins: [new NameConventionPlugin({ convention: "camelCase" })],
+      validate: false,
+    });
+    const out = teikn.generateToStrings(tokens).get("tokens.css")!;
+    // Should contain the resolved color hex in the shadow output (not raw {ref})
+    expect(out).toContain("#abcdef");
+    expect(out).not.toContain("{color");
+  });
+
+  test("Scss: same composite-ref scenario", () => {
+    const tokens: Token[] = [
+      { name: "color-primary", type: "color", value: "#abcdef" },
+      {
+        name: "shadow-card",
+        type: "shadow",
+        value: {
+          color: "{color-primary}",
+          offsetX: "0",
+          offsetY: "2px",
+          blur: "4px",
+          spread: "0",
+        },
+      },
+    ];
+    const teikn = new Teikn({
+      generators: [new Scss(opts)],
+      plugins: [new NameConventionPlugin({ convention: "camelCase" })],
+      validate: false,
+    });
+    const out = teikn.generateToStrings(tokens).get("tokens.scss")!;
+    expect(out).toContain("#abcdef");
+  });
+
+  test("JavaScript: same composite-ref scenario", () => {
+    const tokens: Token[] = [
+      { name: "color-primary", type: "color", value: "#abcdef" },
+      {
+        name: "shadow-card",
+        type: "shadow",
+        value: {
+          color: "{color-primary}",
+          offsetX: "0",
+          offsetY: "2px",
+          blur: "4px",
+          spread: "0",
+        },
+      },
+    ];
+    const teikn = new Teikn({
+      generators: [new JavaScript(opts)],
+      plugins: [new NameConventionPlugin({ convention: "camelCase" })],
+      validate: false,
+    });
+    const out = teikn.generateToStrings(tokens).get("tokens.mjs")!;
+    expect(out).toContain("#abcdef");
+  });
+});
+
+// ─── Scenario 7 — refs in MODE values + NameConvention ───────
+
+describe("Scenario 7 — NameConvention renames refs inside mode values", () => {
+  test("ref in modes.dark resolves after rename (Json)", () => {
+    const tokens: Token[] = [
+      { name: "color-accent", type: "color", value: "#123456" },
+      {
+        name: "surface",
+        type: "color",
+        value: "#ffffff",
+        modes: { dark: "{color-accent}" },
+      },
+    ];
+    const teikn = new Teikn({
+      generators: [new Json()],
+      plugins: [new NameConventionPlugin({ convention: "camelCase" })],
+      validate: false,
+    });
+    const out = teikn.generateToStrings(tokens).get("tokens.json")!;
+    const json = JSON.parse(out);
+    // mode key was "dark" — kebab/camel of "dark" is still "dark".
+    // The accent value should resolve to #123456 (not still a {ref}).
+    const surfaceKey = Object.keys(json).find((k) => k.toLowerCase().includes("surface"))!;
+    expect(JSON.stringify(json[surfaceKey].modes)).toContain("#123456");
+    expect(JSON.stringify(json[surfaceKey].modes)).not.toContain("{color");
+  });
+
+  test("composite ref in modes resolves after rename (CssVars)", () => {
+    const tokens: Token[] = [
+      { name: "color-primary", type: "color", value: "#abcdef" },
+      {
+        name: "shadow-card",
+        type: "shadow",
+        value: { color: "#000", offsetX: "0", offsetY: "2px", blur: "4px", spread: "0" },
+        modes: {
+          dark: {
+            color: "{color-primary}",
+            offsetX: "0",
+            offsetY: "2px",
+            blur: "4px",
+            spread: "0",
+          },
+        },
+      },
+    ];
+    const teikn = new Teikn({
+      generators: [new CssVars(opts)],
+      plugins: [new NameConventionPlugin({ convention: "camelCase" })],
+      validate: false,
+    });
+    const out = teikn.generateToStrings(tokens).get("tokens.css")!;
+    expect(out).toContain("#abcdef");
+    expect(out).not.toContain("{color");
+  });
+});
+
+// ─── Scenario 8 — ColorTransform × AlphaMultiply ─────────────
+
+describe("Scenario 8 — ColorTransform × AlphaMultiply composition", () => {
+  test("both orderings produce identical output (sortPlugins normalizes)", () => {
+    const tokens: Token[] = [{ name: "overlay", type: "color", value: "rgba(0,0,0,0.5)" }];
+    const a = new Json().generate(tokens, [
+      new ColorTransformPlugin({ type: "rgba" }),
+      new AlphaMultiplyPlugin({ background: "#ffffff" }),
+    ]);
+    const b = new Json().generate(tokens, [
+      new AlphaMultiplyPlugin({ background: "#ffffff" }),
+      new ColorTransformPlugin({ type: "rgba" }),
+    ]);
+    expect(a).toBe(b);
+    const j = JSON.parse(a);
+    // After AlphaMultiply on white: ~rgb(127,127,127), then ColorTransform → rgba(...,1)
+    expect(j.overlay.value).toContain("rgba(");
+    expect(j.overlay.value).not.toMatch(/0\.5\b/);
+  });
+
+  test("ColorTransform → hex on alpha color: documents alpha discard via audit only", () => {
+    // ColorTransformPlugin.audit warns on hex when alpha<1; transform itself
+    // still strips alpha silently. Confirm transform behavior.
+    const tokens: Token[] = [{ name: "ghost", type: "color", value: "rgba(255,0,0,0.25)" }];
+    const out = new Json().generate(tokens, [new ColorTransformPlugin({ type: "hex" })]);
+    const j = JSON.parse(out);
+    // Behavior: alpha silently discarded in transform output.
+    expect(j.ghost.value).toMatch(/^#[0-9a-fA-F]{6,8}$/);
+  });
+});
+
+// ─── Scenario 9 — ScssQuoteValue × NameConvention ────────────
+
+describe("Scenario 9 — ScssQuoteValue × NameConvention", () => {
+  test("font-family token gets both rename and quoting", () => {
+    const tokens: Token[] = [
+      { name: "body-font", type: "font-family", value: "Inter, sans-serif" },
+    ];
+    const out = new Scss(opts).generate(tokens, [
+      new ScssQuoteValuePlugin(),
+      new NameConventionPlugin({ convention: "camelCase" }),
+    ]);
+    // bodyFont becomes the name; unquote wrapping is in value
+    expect(out).toContain("unquote");
+    expect(out).toContain("Inter");
+  });
+
+  test("reversing registration order yields identical output", () => {
+    const tokens: Token[] = [
+      { name: "body-font", type: "font-family", value: "Inter, sans-serif" },
+    ];
+    const a = new Scss(opts).generate(tokens, [
+      new ScssQuoteValuePlugin(),
+      new NameConventionPlugin({ convention: "camelCase" }),
+    ]);
+    const b = new Scss(opts).generate(tokens, [
+      new NameConventionPlugin({ convention: "camelCase" }),
+      new ScssQuoteValuePlugin(),
+    ]);
+    expect(a).toBe(b);
+  });
+});
+
+// ─── Scenario 10 — plugin sees ref string vs resolved value ──
+
+describe("Scenario 10 — plugin transform sees ref string at generator level", () => {
+  // DESIGN QUESTION: when calling Generator.generate() directly (bypassing
+  // Teikn), refs are NOT resolved. ColorTransformPlugin defensively skips
+  // values starting with "{". Other plugins (e.g. RemUnit) may not.
+  test("ColorTransform skips ref string values", () => {
+    const tokens: Token[] = [
+      { name: "primary", type: "color", value: "#ff0000" },
+      { name: "alias", type: "color", value: "{primary}" },
+    ];
+    const out = new Json().generate(tokens, [new ColorTransformPlugin({ type: "rgba" })]);
+    const j = JSON.parse(out);
+    expect(j.primary.value).toContain("rgba(");
+    // alias is left as the raw ref string — plugin defensively skipped it
+    expect(j.alias.value).toBe("{primary}");
+  });
+
+  test("Via full Teikn pipeline, refs are resolved before plugin runs", () => {
+    const tokens: Token[] = [
+      { name: "primary", type: "color", value: "#ff0000" },
+      { name: "alias", type: "color", value: "{primary}" },
+    ];
+    const teikn = new Teikn({
+      generators: [new Json()],
+      plugins: [new ColorTransformPlugin({ type: "rgba" })],
+      validate: false,
+    });
+    const out = teikn.generateToStrings(tokens).get("tokens.json")!;
+    const j = JSON.parse(out);
+    // Both should be transformed because Teikn resolved {primary} → "#ff0000"
+    const aliasKey = Object.keys(j).find((k) => k.toLowerCase().includes("alias"))!;
+    expect(j[aliasKey].value).toContain("rgba(");
+  });
+});
+
+// ─── Scenario 11 — plugin runs on mode values ─────────────────
+
+describe("Scenario 11 — plugin transforms apply to mode values", () => {
+  test("RemUnitPlugin converts px in modes", () => {
+    const tokens: Token[] = [
+      { name: "gap", type: "spacing", value: "16px", modes: { dense: "8px", loose: "32px" } },
+    ];
+    const out = new Json().generate(tokens, [new RemUnitPlugin({ base: 16 })]);
+    const j = JSON.parse(out);
+    expect(j.gap.value).toBe("1rem");
+    expect(j.gap.modes.dense).toBe("0.5rem");
+    expect(j.gap.modes.loose).toBe("2rem");
+  });
+
+  test("ClampPlugin behavior in modes", () => {
+    const tokens: Token[] = [
+      {
+        name: "size",
+        type: "font-size",
+        value: "16px",
+        modes: { large: "24px" },
+      },
+    ];
+    // ClampPlugin requires options — explore minimal usage
+    const plugin = new ClampPlugin({
+      tokens: { size: { min: "12px", max: "20px" } },
+    });
+    const out = new Json().generate(tokens, [plugin]);
+    const j = JSON.parse(out);
+    // Document: does ClampPlugin's tokens-map-keyed behavior apply to modes?
+    // Observed: clamp() string in value; modes may or may not match.
+    expect(typeof j.size.value).toBe("string");
+  });
+});
+
+// ─── Scenario 12 — empty plugin list ──────────────────────────
+
+describe("Scenario 12 — empty plugin list", () => {
+  test("Teikn with plugins: [] still generates", () => {
+    const tokens: Token[] = [{ name: "primary", type: "color", value: "#ff0000" }];
+    const teikn = new Teikn({
+      generators: [new Json()],
+      plugins: [],
+      validate: false,
+    });
+    const out = teikn.generateToStrings(tokens).get("tokens.json")!;
+    const j = JSON.parse(out);
+    // Type prefixing is built-in
+    expect(Object.keys(j).some((k) => k.toLowerCase().includes("primary"))).toBe(true);
+  });
+
+  test("Generator.generate with []  plugins is a noop", () => {
+    const tokens: Token[] = [{ name: "primary", type: "color", value: "#ff0000" }];
+    const out = new Json().generate(tokens, []);
+    expect(JSON.parse(out).primary.value).toBe("#ff0000");
+  });
+});
+
+// ─── Scenario 13 — plugin transform throws ────────────────────
+
+describe("Scenario 13 — plugin transform throws", () => {
+  test("error from plugin.transform does NOT include the token name in the message", () => {
+    // BUG / design question: applyPlugin in Generator.ts validates the
+    // RESULT of plugin.transform but does not try/catch around the call.
+    // A thrown error propagates raw — the caller has to guess which token
+    // tripped the plugin.
+    class Bomb extends Plugin {
+      tokenType: RegExp = /.*/;
+      outputType: RegExp = /.*/;
+      override transform(token: Token): Token {
+        if (token.name === "boom") {
+          throw new Error("kaboom");
+        }
+        return token;
+      }
+    }
+    const tokens: Token[] = [
+      { name: "ok", type: "color", value: "#000" },
+      { name: "boom", type: "color", value: "#fff" },
+    ];
+    let err: Error | undefined;
+    try {
+      new Json().generate(tokens, [new Bomb()]);
+    } catch (e) {
+      err = e as Error;
+    }
+    expect(err).toBeDefined();
+    // BUG: observed — error message is just "kaboom". Expected: should
+    // mention either the plugin class name ("Bomb") or the token name ("boom")
+    // to be actionable. applyPlugin already wraps malformed RETURN values
+    // with context; it should similarly wrap thrown errors.
+    expect(err!.message).toBe("kaboom");
+    // The following would be the desired behavior — leaving as documentation:
+    // expect(err!.message).toMatch(/boom|Bomb/);
+  });
+});
+
+// ─── Scenario 14 — generator prefix with special characters ──
+
+describe("Scenario 14 — generator prefix with special characters", () => {
+  // Note: "prefix" is a generator option (CssVars/Scss/ScssVars), not a
+  // plugin option. PrefixTypePlugin is rejected by Teikn entirely. Test
+  // generators with edge-case prefixes against plugins.
+  test("CssVars prefix with double-dash characters", () => {
+    const tokens: Token[] = [{ name: "primary", type: "color", value: "#ff0000" }];
+    const out = new CssVars({ ...opts, prefix: "--weird" } as Parameters<
+      (typeof CssVars)["prototype"]["generate"]
+    > extends never
+      ? never
+      : ConstructorParameters<typeof CssVars>[0]).generate(tokens, [
+      new NameConventionPlugin({ convention: "kebab-case" }),
+    ]);
+    // Document what shows up — could yield `----weird-...` which is invalid CSS
+    // BUG candidate: no sanitization of prefix means leading `--` can produce
+    // `----weird` style custom properties. CSS allows custom properties to
+    // start with `--`, but `----weird` is technically valid yet surprising.
+    expect(out).toContain("weird");
+  });
+
+  test("Scss prefix with leading digit", () => {
+    const tokens: Token[] = [{ name: "primary", type: "color", value: "#ff0000" }];
+    const out = new Scss({ ...opts, prefix: "1bad" } as ConstructorParameters<
+      typeof Scss
+    >[0]).generate(tokens, [new NameConventionPlugin({ convention: "kebab-case" })]);
+    // BUG: Scss accepts a `prefix` option (declared via PrefixOptions in
+    // ScssOpts), but `Scss.generateToken` / `combinator` never reads it —
+    // see src/Generators/Scss.ts where `composeName` from prefix-utils is
+    // not invoked. Observed: prefix is silently dropped (no "1bad" anywhere).
+    // Expected: either apply the prefix consistently (like CssVars does
+    // for `--prefix-name`) or throw on the unsupported option.
+    expect(out).not.toContain("1bad");
+  });
+
+  test("ScssVars prefix containing $", () => {
+    const tokens: Token[] = [{ name: "primary", type: "color", value: "#ff0000" }];
+    const out = new ScssVars({ ...opts, prefix: "$weird" } as ConstructorParameters<
+      typeof ScssVars
+    >[0]).generate(tokens, []);
+    // BUG candidate: `$$weird-...` is not a legal SCSS variable.
+    expect(out).toBeDefined();
+  });
+});
+
+// ─── Scenario 15 — DeprecationPlugin across generators ───────
+
+describe("Scenario 15 — DeprecationPlugin output across generators", () => {
+  const plugin = new DeprecationPlugin({ tokens: { old: "new" } });
+  const tokens: Token[] = [
+    { name: "old", type: "color", value: "#000" },
+    { name: "new", type: "color", value: "#fff" },
+  ];
+
+  test("Json output exposes deprecated:true on the token", () => {
+    const j = JSON.parse(new Json().generate(tokens, [plugin]));
+    expect(j.old.deprecated).toBe(true);
+  });
+
+  test("CssVars: deprecation surfaces in a comment or annotation", () => {
+    const out = new CssVars(opts).generate(tokens, [plugin]);
+    // BUG candidate: CssVars output emits the deprecated token alongside
+    // valid tokens without any comment/marker. Consumers have no way to
+    // know "old" is deprecated from CSS output alone.
+    expect(out).toContain("--old");
+    // OBSERVED: CssVars does emit "DEPRECATED" text via usage-derived
+    // comments on the token. Verify it shows up somewhere consumable.
+    expect(out.toLowerCase()).toContain("deprecated");
+  });
+
+  test("Scss: deprecation surfaces in a comment or annotation", () => {
+    const out = new Scss(opts).generate(tokens, [plugin]);
+    // Same behavioral note as CssVars.
+    expect(out).toContain("old");
+  });
+});
+
+// ─── Scenario 16 — ContrastValidatorPlugin loudness ──────────
+
+describe("Scenario 16 — ContrastValidatorPlugin failure mode", () => {
+  test("audit reports insufficient contrast but generate() does NOT fail", () => {
+    // DESIGN QUESTION: ContrastValidatorPlugin only implements audit().
+    // Calling .generate() (or Teikn.generateToStrings) completes successfully
+    // even when contrast is below WCAG threshold. Issues are only surfaced
+    // via .audit() / .transform() flow. Generators bypass this.
+    const tokens: Token[] = [
+      { name: "fg", type: "color", value: "#888888" },
+      { name: "bg", type: "color", value: "#999999" },
+    ];
+    const plugin = new ContrastValidatorPlugin({
+      pairs: [{ foreground: "fg", background: "bg", level: "AAA" }],
+    });
+    // Direct audit — returns issues
+    const issues = plugin.audit!(tokens);
+    expect(issues.length).toBeGreaterThan(0);
+    expect(issues[0]!.severity).toBe("error");
+    expect(issues[0]!.message).toMatch(/contrast/i);
+    // Through Teikn — generates files successfully, doesn't throw
+    const teikn = new Teikn({
+      generators: [new Json()],
+      plugins: [plugin],
+      validate: false,
+    });
+    expect(() => teikn.generateToStrings(tokens)).not.toThrow();
+    // The audit method surfaces issues only when consumer calls .transform()
+    // (the Teikn method, not Plugin.transform) which returns {auditIssues, ...}.
+  });
+});
+
+// ─── Scenario 6/7 deep — composed BoxShadow refs (alpha.12 regression) ──
+
+describe("Alpha.12 deep — refs deep inside first-class BoxShadow", () => {
+  test("BoxShadow constructed with new Color from {ref}: rename preserves chain", () => {
+    // The alpha.12 fix was about composite VALUES (plain objects) containing
+    // refs. First-class BoxShadow instances are constructed eagerly and don't
+    // carry ref strings — so this is a doc-only smoke test.
+    const tokens: Token[] = [
+      { name: "color-primary", type: "color", value: new Color("#abcdef") },
+      {
+        name: "shadow-card",
+        type: "shadow",
+        value: new BoxShadow({
+          color: new Color("#abcdef"),
+          offsetX: 0,
+          offsetY: 2,
+          blur: 4,
+          spread: 0,
+        }),
+      },
+    ];
+    const teikn = new Teikn({
+      generators: [new CssVars(opts)],
+      plugins: [new NameConventionPlugin({ convention: "camelCase" })],
+      validate: false,
+    });
+    const out = teikn.generateToStrings(tokens).get("tokens.css")!;
+    // Color serializes to rgb(...) form here, not the hex literal. Document
+    // the rgb form is present and refs are not raw strings.
+    expect(out).toContain("rgb(171, 205, 239)");
+    expect(out).not.toContain("{color");
+  });
+});

--- a/src/Plugins/plugin-stress.test.ts
+++ b/src/Plugins/plugin-stress.test.ts
@@ -470,11 +470,7 @@ describe("Scenario 12 — empty plugin list", () => {
 // ─── Scenario 13 — plugin transform throws ────────────────────
 
 describe("Scenario 13 — plugin transform throws", () => {
-  test("error from plugin.transform does NOT include the token name in the message", () => {
-    // BUG / design question: applyPlugin in Generator.ts validates the
-    // RESULT of plugin.transform but does not try/catch around the call.
-    // A thrown error propagates raw — the caller has to guess which token
-    // tripped the plugin.
+  test("error from plugin.transform is wrapped with plugin + token context", () => {
     class Bomb extends Plugin {
       tokenType: RegExp = /.*/;
       outputType: RegExp = /.*/;
@@ -496,13 +492,9 @@ describe("Scenario 13 — plugin transform throws", () => {
       err = e as Error;
     }
     expect(err).toBeDefined();
-    // BUG: observed — error message is just "kaboom". Expected: should
-    // mention either the plugin class name ("Bomb") or the token name ("boom")
-    // to be actionable. applyPlugin already wraps malformed RETURN values
-    // with context; it should similarly wrap thrown errors.
-    expect(err!.message).toBe("kaboom");
-    // The following would be the desired behavior — leaving as documentation:
-    // expect(err!.message).toMatch(/boom|Bomb/);
+    expect(err!.message).toMatch(/Bomb/);
+    expect(err!.message).toMatch(/boom/);
+    expect(err!.message).toMatch(/kaboom/);
   });
 });
 

--- a/src/Plugins/plugin-stress.test.ts
+++ b/src/Plugins/plugin-stress.test.ts
@@ -382,11 +382,11 @@ describe("Scenario 9 — ScssQuoteValue × NameConvention", () => {
 
 // ─── Scenario 10 — plugin sees ref string vs resolved value ──
 
-describe("Scenario 10 — plugin transform sees ref string at generator level", () => {
-  // DESIGN QUESTION: when calling Generator.generate() directly (bypassing
-  // Teikn), refs are NOT resolved. ColorTransformPlugin defensively skips
-  // values starting with "{". Other plugins (e.g. RemUnit) may not.
-  test("ColorTransform skips ref string values", () => {
+describe("Scenario 10 — plugins always see resolved values", () => {
+  // `Generator.generate` resolves refs internally before running plugins
+  // (matches Teikn.generateToStrings' contract), so plugins never observe
+  // raw `{ref}` strings regardless of entry point.
+  test("Generator.generate resolves refs before plugins run", () => {
     const tokens: Token[] = [
       { name: "primary", type: "color", value: "#ff0000" },
       { name: "alias", type: "color", value: "{primary}" },
@@ -394,8 +394,8 @@ describe("Scenario 10 — plugin transform sees ref string at generator level", 
     const out = new Json().generate(tokens, [new ColorTransformPlugin({ type: "rgba" })]);
     const j = JSON.parse(out);
     expect(j.primary.value).toContain("rgba(");
-    // alias is left as the raw ref string — plugin defensively skipped it
-    expect(j.alias.value).toBe("{primary}");
+    // alias is also transformed because the ref was resolved first.
+    expect(j.alias.value).toContain("rgba(");
   });
 
   test("Via full Teikn pipeline, refs are resolved before plugin runs", () => {

--- a/src/Plugins/plugin-stress.test.ts
+++ b/src/Plugins/plugin-stress.test.ts
@@ -8,6 +8,7 @@ import { Scss } from "../Generators/Scss.js";
 import { ScssVars } from "../Generators/ScssVars.js";
 import { JavaScript } from "../Generators/JavaScript.js";
 import { Json } from "../Generators/Json.js";
+import { TypeScriptDeclarations } from "../Generators/TypeScriptDeclarations.js";
 import { Teikn } from "../Teikn.js";
 import { Plugin, sortPlugins } from "./Plugin.js";
 import { AlphaMultiplyPlugin } from "./AlphaMultiplyPlugin.js";
@@ -559,21 +560,26 @@ describe("Scenario 15 — DeprecationPlugin output across generators", () => {
     expect(j.old.deprecated).toBe(true);
   });
 
-  test("CssVars: deprecation surfaces in a comment or annotation", () => {
+  test("CssVars surfaces deprecation in the var's usage comment", () => {
     const out = new CssVars(opts).generate(tokens, [plugin]);
-    // BUG candidate: CssVars output emits the deprecated token alongside
-    // valid tokens without any comment/marker. Consumers have no way to
-    // know "old" is deprecated from CSS output alone.
     expect(out).toContain("--old");
-    // OBSERVED: CssVars does emit "DEPRECATED" text via usage-derived
-    // comments on the token. Verify it shows up somewhere consumable.
     expect(out.toLowerCase()).toContain("deprecated");
   });
 
-  test("Scss: deprecation surfaces in a comment or annotation", () => {
+  test("Scss surfaces deprecation in the map entry's usage comment", () => {
     const out = new Scss(opts).generate(tokens, [plugin]);
-    // Same behavioral note as CssVars.
     expect(out).toContain("old");
+    expect(out.toLowerCase()).toContain("deprecated");
+  });
+
+  test("JavaScript emits @deprecated JSDoc with replacement name", () => {
+    const out = new JavaScript({ dateFn: () => "FIXED" }).generate(tokens, [plugin]);
+    expect(out).toMatch(/@deprecated use `new` instead[\s\S]*old:/);
+  });
+
+  test("TypeScriptDeclarations emits @deprecated JSDoc with replacement name", () => {
+    const out = new TypeScriptDeclarations({ dateFn: () => "FIXED" }).generate(tokens, [plugin]);
+    expect(out).toMatch(/@deprecated use `new` instead[\s\S]*readonly old/);
   });
 });
 

--- a/src/Plugins/plugin-stress.test.ts
+++ b/src/Plugins/plugin-stress.test.ts
@@ -527,18 +527,12 @@ describe("Scenario 14 — generator prefix with special characters", () => {
     expect(out).toContain("weird");
   });
 
-  test("Scss prefix with leading digit", () => {
+  test("Scss applies prefix to map keys and get-token usage", () => {
     const tokens: Token[] = [{ name: "primary", type: "color", value: "#ff0000" }];
-    const out = new Scss({ ...opts, prefix: "1bad" } as ConstructorParameters<
+    const out = new Scss({ ...opts, prefix: "myco" } as ConstructorParameters<
       typeof Scss
     >[0]).generate(tokens, [new NameConventionPlugin({ convention: "kebab-case" })]);
-    // BUG: Scss accepts a `prefix` option (declared via PrefixOptions in
-    // ScssOpts), but `Scss.generateToken` / `combinator` never reads it —
-    // see src/Generators/Scss.ts where `composeName` from prefix-utils is
-    // not invoked. Observed: prefix is silently dropped (no "1bad" anywhere).
-    // Expected: either apply the prefix consistently (like CssVars does
-    // for `--prefix-name`) or throw on the unsupported option.
-    expect(out).not.toContain("1bad");
+    expect(out).toContain("myco-primary");
   });
 
   test("ScssVars prefix containing $", () => {

--- a/src/Teikn.test.ts
+++ b/src/Teikn.test.ts
@@ -206,14 +206,14 @@ describe("Teikn", () => {
       ).toThrow("PrefixTypePlugin is no longer needed");
     });
 
-    test("last-write-wins when the same prefixed name appears twice", () => {
+    test("duplicate prefixed names are rejected as a validation error", () => {
       const first = group("color", { primary: "#0066cc" });
       const second = group("color", { primary: "#ff0000" });
 
       const writer = new Teikn({ generators: [new Json()] });
-      const json = parseOutput(writer, tokens(first, second));
-
-      expect(json.colorPrimary.value).toBe("#ff0000");
+      expect(() => writer.generateToStrings(tokens(first, second))).toThrow(
+        /Duplicate qualified token name/,
+      );
     });
 
     test("does not mutate input token names", () => {

--- a/src/Teikn.ts
+++ b/src/Teikn.ts
@@ -320,7 +320,26 @@ export class Teikn {
 
     const results = new Map<string, string>();
     for (const generator of this.generators) {
-      for (const [filename, content] of generator.generateFiles(named, this.plugins)) {
+      const declared = new Set(generator.filenames());
+      const produced = generator.generateFiles(named, this.plugins);
+      const emitted = new Set(produced.keys());
+
+      const undeclared = [...emitted].filter((k) => !declared.has(k));
+      if (undeclared.length > 0) {
+        throw new Error(
+          `Generator \`${generator.constructor.name}\` emitted file(s) it did not declare in filenames(): ${undeclared.join(", ")}. ` +
+            `This is a bug in the generator's generateFiles() implementation — declared keys and emitted keys must match.`,
+        );
+      }
+      const missing = [...declared].filter((k) => !emitted.has(k));
+      if (missing.length > 0) {
+        throw new Error(
+          `Generator \`${generator.constructor.name}\` declared filename(s) in filenames() but did not emit them from generateFiles(): ${missing.join(", ")}. ` +
+            `This is a bug in the generator's generateFiles() implementation — declared keys and emitted keys must match.`,
+        );
+      }
+
+      for (const [filename, content] of produced) {
         results.set(filename, content);
       }
     }

--- a/src/Teikn.ts
+++ b/src/Teikn.ts
@@ -203,19 +203,44 @@ export class Teikn {
     this.options = options;
     this.generators = generators ?? [new Teikn.generators.Json()];
 
-    const filenames = this.generators.flatMap((g) => g.filenames());
-    // Compare case-insensitively so pairs like `Tokens.mjs` / `tokens.mjs`
-    // are caught on case-insensitive filesystems (macOS, Windows) where
-    // both writes would target the same underlying file.
+    // Check intra-generator duplicates first — a single generator declaring
+    // the same filename twice is a bug in that generator, not a configuration
+    // problem the user can fix by setting `filename`.
+    for (const g of this.generators) {
+      const own = g.filenames();
+      const seen = new Set<string>();
+      const dupes = new Set<string>();
+      for (const filename of own) {
+        const key = filename.toLowerCase();
+        if (seen.has(key)) {
+          dupes.add(filename);
+        } else {
+          seen.add(key);
+        }
+      }
+      if (dupes.size > 0) {
+        throw new Error(
+          `Generator \`${g.constructor.name}\` declared duplicate output filenames: ${[...dupes].join(", ")}. ` +
+            `This is a bug in the generator's filenames() implementation, not user configuration.`,
+        );
+      }
+    }
+
+    // Then check cross-generator duplicates — those *are* user-fixable via
+    // the `filename` option. Compare case-insensitively so pairs like
+    // `Tokens.mjs` / `tokens.mjs` are caught on case-insensitive filesystems
+    // (macOS, Windows) where both writes would target the same file.
     const seen = new Map<string, string>();
     const dupes: string[] = [];
-    for (const filename of filenames) {
-      const key = filename.toLowerCase();
-      const prior = seen.get(key);
-      if (prior !== undefined) {
-        dupes.push(prior === filename ? filename : `${prior} / ${filename}`);
-      } else {
-        seen.set(key, filename);
+    for (const g of this.generators) {
+      for (const filename of g.filenames()) {
+        const key = filename.toLowerCase();
+        const prior = seen.get(key);
+        if (prior !== undefined) {
+          dupes.push(prior === filename ? filename : `${prior} / ${filename}`);
+        } else {
+          seen.set(key, filename);
+        }
       }
     }
     if (dupes.length > 0) {

--- a/src/Token.ts
+++ b/src/Token.ts
@@ -32,6 +32,13 @@ export type Token = {
   type: string;
   group?: string;
   modes?: ModeValues;
+  /**
+   * Set by `DeprecationPlugin`. When `true`, the token is deprecated.
+   * When a string, generators may surface it as a deprecation reason.
+   */
+  deprecated?: boolean;
+  /** Set by `DeprecationPlugin` when a replacement token is named. */
+  replacement?: string;
 };
 
 export type TokenInput = TokenValue | [value: TokenValue, usage: string] | TokenInputObject;

--- a/src/TokenTypes/BoxShadow.ts
+++ b/src/TokenTypes/BoxShadow.ts
@@ -1,5 +1,6 @@
 import { splitTopLevel } from "../string-utils.js";
 import { Color } from "./Color/index.js";
+import { assertNotRef } from "./ref-guard.js";
 
 const lengthRe = /^(-?\d+(?:\.\d+)?)(px|rem|em)?/;
 
@@ -102,6 +103,7 @@ export class BoxShadow {
     }
 
     if (typeof first === "string") {
+      assertNotRef(first, "BoxShadow");
       const parsed = parse(first);
       this.#offsetX = parsed.offsetX;
       this.#offsetY = parsed.offsetY;
@@ -220,6 +222,7 @@ export class BoxShadowList {
     }
 
     if (typeof first === "string") {
+      assertNotRef(first, "BoxShadowList");
       this.#layers = splitTopLevel(first).map((s) => new BoxShadow(s));
       return;
     }

--- a/src/TokenTypes/Color/Color.ts
+++ b/src/TokenTypes/Color/Color.ts
@@ -1,3 +1,4 @@
+import { assertNotRef } from "../ref-guard.js";
 import type { Space, SpaceData } from "./ColorSpace.js";
 import { convertWithIntermediates } from "./ColorSpace.js";
 import { RGBToHex } from "./conversions.js";
@@ -150,6 +151,7 @@ export class Color {
 
     // String constructor
     if (typeof r === "string") {
+      assertNotRef(r, "Color");
       const parsed = parseColorString(r);
       this.#nativeSpace = parsed.space;
       this.#nativeData = parsed.data;

--- a/src/TokenTypes/CubicBezier.ts
+++ b/src/TokenTypes/CubicBezier.ts
@@ -1,4 +1,5 @@
 import { clamp } from "../utils.js";
+import { assertNotRef } from "./ref-guard.js";
 
 const EPSILON = 1e-6;
 const MAX_ITERATIONS = 8;
@@ -98,6 +99,7 @@ export class CubicBezier {
     }
 
     if (typeof first === "string") {
+      assertNotRef(first, "CubicBezier");
       const named = presets[first.trim().toLowerCase()];
       if (named) {
         [this.#x1, this.#y1, this.#x2, this.#y2] = named;

--- a/src/TokenTypes/Dimension.ts
+++ b/src/TokenTypes/Dimension.ts
@@ -1,3 +1,5 @@
+import { assertNotRef } from "./ref-guard.js";
+
 // ─── Unit Types ─────────────────────────────────────────────
 
 export type AbsoluteUnit = "px" | "cm" | "mm" | "in" | "pt" | "pc" | "Q";
@@ -177,6 +179,7 @@ export class Dimension {
     }
 
     if (typeof first === "string") {
+      assertNotRef(first, "Dimension");
       const parsed = parseCss(first);
       this.#value = parsed.value;
       this.#unit = parsed.unit;

--- a/src/TokenTypes/Duration.ts
+++ b/src/TokenTypes/Duration.ts
@@ -1,3 +1,5 @@
+import { assertNotRef } from "./ref-guard.js";
+
 // ─── Unit Type ──────────────────────────────────────────────
 
 export type DurationUnit = "ms" | "s";
@@ -48,6 +50,7 @@ export class Duration {
     }
 
     if (typeof first === "string") {
+      assertNotRef(first, "Duration");
       const parsed = parseCss(first);
       this.#value = parsed.value;
       this.#unit = parsed.unit;

--- a/src/TokenTypes/Gradient.ts
+++ b/src/TokenTypes/Gradient.ts
@@ -1,5 +1,6 @@
 import { splitTopLevel } from "../string-utils.js";
 import { Color } from "./Color/index.js";
+import { assertNotRef } from "./ref-guard.js";
 
 // ─── Shared types ─────────────────────────────────────────────
 
@@ -131,6 +132,7 @@ export class LinearGradient {
     }
 
     if (typeof first === "string") {
+      assertNotRef(first, "LinearGradient");
       const m = first.match(linearRe);
       if (!m) {
         throw new Error(`Invalid linear-gradient: "${first}"`);
@@ -253,6 +255,7 @@ export class RadialGradient {
     }
 
     if (typeof first === "string") {
+      assertNotRef(first, "RadialGradient");
       const m = first.match(radialRe);
       if (!m) {
         throw new Error(`Invalid radial-gradient: "${first}"`);
@@ -412,6 +415,7 @@ export class GradientList {
     }
 
     if (typeof first === "string") {
+      assertNotRef(first, "GradientList");
       this.#layers = splitTopLevel(first).map(parseGradient);
       return;
     }

--- a/src/TokenTypes/Transition.ts
+++ b/src/TokenTypes/Transition.ts
@@ -1,6 +1,7 @@
 import { splitTopLevel } from "../string-utils.js";
 import { CubicBezier } from "./CubicBezier.js";
 import { Duration } from "./Duration.js";
+import { assertNotRef } from "./ref-guard.js";
 
 const timeRe = /^(\d+(?:\.\d+)?)(ms|s)$/;
 
@@ -108,6 +109,7 @@ export class Transition {
     }
 
     if (typeof first === "string" && timingFunction === undefined) {
+      assertNotRef(first, "Transition");
       const parsed = parse(first);
       this.#duration = new Duration(parsed.duration);
       this.#timingFunction = parsed.timingFunction;
@@ -259,6 +261,7 @@ export class TransitionList {
     }
 
     if (typeof first === "string") {
+      assertNotRef(first, "TransitionList");
       this.#layers = splitTopLevel(first).map((s) => new Transition(s));
       return;
     }

--- a/src/TokenTypes/ref-guard.ts
+++ b/src/TokenTypes/ref-guard.ts
@@ -1,0 +1,17 @@
+const REF_RE = /^\{[^}]+\}$/;
+
+export const assertNotRef = (input: unknown, typeName: string): void => {
+  if (typeof input !== "string") {
+    return;
+  }
+  const trimmed = input.trim();
+  if (!REF_RE.test(trimmed)) {
+    return;
+  }
+  throw new Error(
+    `${typeName} cannot be constructed from a reference string ${trimmed}. ` +
+      `References inside first-class value wrappers are not resolved. ` +
+      `Either: (a) make the whole token value a reference (\`value: "${trimmed}"\` with no wrapper), ` +
+      `or (b) use the plain composite-object form so the ref can be resolved per-field.`,
+  );
+};

--- a/src/fuzz/edge-case-probes.test.ts
+++ b/src/fuzz/edge-case-probes.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+
+import { composite, group, tokens as combineTokens } from "../builders.js";
+import {
+  CssVars,
+  DtcgGenerator,
+  Html,
+  JavaScript,
+  Json,
+  Scss,
+  ScssVars,
+  Storybook,
+  TypeScript,
+  TypeScriptDeclarations,
+} from "../Generators/index.js";
+import { Teikn } from "../Teikn.js";
+import { Color } from "../TokenTypes/Color/index.js";
+import { Duration } from "../TokenTypes/Duration.js";
+
+const dateFn = () => "FIXED";
+const gens = () => [
+  new CssVars({ dateFn }),
+  new Scss({ filename: "a", dateFn }),
+  new ScssVars({ filename: "b", dateFn }),
+  new Html({ dateFn }),
+  new Json(),
+  new DtcgGenerator(),
+  new JavaScript({ filename: "c", dateFn }),
+  new TypeScript({ filename: "d", dateFn }),
+  new TypeScriptDeclarations({ filename: "e", dateFn }),
+  new Storybook({ filename: "f", dateFn }),
+];
+
+describe("aggressive probes", () => {
+  it("Transition with referenced duration", () => {
+    const durs = group("duration", { fast: new Duration(100, "ms") });
+    const transitions = composite("transition", {
+      hover: { duration: "{fast}", timingFunction: "ease-in-out" },
+    });
+    const t = new Teikn({ generators: gens(), validate: false });
+    expect(() => t.generateToStrings(combineTokens(durs, transitions))).not.toThrow();
+  });
+
+  it("Token value containing braces but not a valid ref", () => {
+    const g = group("text", { weird: "hello {not-a-ref} world" });
+    const t = new Teikn({ generators: gens(), validate: false });
+    expect(() => t.generateToStrings(g)).not.toThrow();
+  });
+
+  it("Token name with parens / brackets", () => {
+    const g = group("color", {
+      "weird(name)": new Color(0, 0, 0),
+      "name[1]": new Color(1, 1, 1),
+    });
+    const t = new Teikn({ generators: gens(), validate: false });
+    expect(() => t.generateToStrings(g)).not.toThrow();
+  });
+
+  it("Empty modes object", () => {
+    const g = group("color", { primary: { value: new Color(0, 0, 0), modes: {} } });
+    const t = new Teikn({ generators: gens(), validate: false });
+    expect(() => t.generateToStrings(g)).not.toThrow();
+  });
+
+  it("Token value with newline characters", () => {
+    const g = group("text", { multiline: "line1\nline2" });
+    const t = new Teikn({ generators: gens(), validate: false });
+    expect(() => t.generateToStrings(g)).not.toThrow();
+  });
+
+  it("Token value with embedded double quotes", () => {
+    const g = group("text", { quoted: 'he said "hi"', apos: "it's" });
+    const t = new Teikn({ generators: gens(), validate: false });
+    expect(() => t.generateToStrings(g)).not.toThrow();
+  });
+
+  it("Token with backslashes", () => {
+    const g = group("text", { back: "a\\b" });
+    const t = new Teikn({ generators: gens(), validate: false });
+    expect(() => t.generateToStrings(g)).not.toThrow();
+  });
+
+  it("Very long token name (200 chars)", () => {
+    const long = "a".repeat(200);
+    const g = group("text", { [long]: "value" });
+    const t = new Teikn({ generators: gens(), validate: false });
+    expect(() => t.generateToStrings(g)).not.toThrow();
+  });
+
+  it("Round-trip JSON output: quotes/newlines/backslashes are valid JSON", () => {
+    const g = group("text", {
+      quoted: 'a "b" c',
+      multiline: "x\ny",
+      back: "a\\b",
+    });
+    const t = new Teikn({
+      generators: [new Json()],
+      validate: false,
+    });
+    const out = t.generateToStrings(g);
+    const json = out.get("tokens.json")!;
+    expect(() => JSON.parse(json)).not.toThrow();
+    const parsed = JSON.parse(json);
+    // The value path under the prefix-named token should round-trip
+    // (we don't depend on exact shape here, just on parseability)
+    expect(parsed).toBeTruthy();
+  });
+
+  it("Token name colliding with a JS reserved word", () => {
+    const g = group("color", {
+      class: new Color(1, 2, 3),
+      delete: new Color(4, 5, 6),
+      import: new Color(7, 8, 9),
+    });
+    const t = new Teikn({ generators: gens(), validate: false });
+    expect(() => t.generateToStrings(g)).not.toThrow();
+  });
+});

--- a/src/fuzz/token-graph.fuzz.test.ts
+++ b/src/fuzz/token-graph.fuzz.test.ts
@@ -31,7 +31,6 @@ import {
   StripTypePrefixPlugin,
 } from "../Plugins/index.js";
 import { Teikn } from "../Teikn.js";
-import type { TeiknOptions } from "../Teikn.ts";
 import { BoxShadow } from "../TokenTypes/BoxShadow.js";
 import { Color } from "../TokenTypes/Color/index.js";
 import { CubicBezier } from "../TokenTypes/CubicBezier.js";
@@ -292,21 +291,19 @@ describe("token-graph fuzz", () => {
     it(`seed=${seed}: all generators emit non-empty output and are deterministic`, () => {
       const rng = makeRng(seed);
       const toks = buildGraph(rng, { tricky: chance(rng, 0.7) });
-      const plugins = allPlugins(rng);
+      // Build the plugin list from a dedicated rng seeded per-test so both
+      // Teikn instances below share an identical, reproducible plugin set.
+      const buildPlugins = () => allPlugins(makeRng(seed));
 
-      const opts: TeiknOptions = {
+      const t1 = new Teikn({
         generators: buildGenerators(),
-        plugins,
+        plugins: buildPlugins(),
         validate: false,
-      };
-
-      const t1 = new Teikn(opts);
-      // BUG: `_t2` is constructed but determinism check below mistakenly
-      // reuses `t1`. Pinned for follow-up; renaming preserves current behavior.
-      const _t2 = new Teikn({
-        ...opts,
+      });
+      const t2 = new Teikn({
         generators: buildGenerators(),
-        plugins: allPlugins(makeRng(seed)).slice(0, plugins.length),
+        plugins: buildPlugins(),
+        validate: false,
       });
 
       let out1: Map<string, string>;
@@ -349,13 +346,21 @@ describe("token-graph fuzz", () => {
         expect(cssContent.includes(":"), `CSS missing declarations (seed=${seed})`).toBe(true);
       }
 
-      // Determinism: same input + same plugins should produce identical output
-      // (Use the same Teikn instance generators reused on the same input.)
-      const out2 = t1.generateToStrings(toks);
+      // Determinism — same instance, second call (idempotence)
+      const out1b = t1.generateToStrings(toks);
+      for (const [filename, content] of out1) {
+        expect(
+          out1b.get(filename),
+          `non-deterministic on second call (same instance): ${filename} (seed=${seed})`,
+        ).toBe(content);
+      }
+
+      // Determinism — different instance built from the same seed
+      const out2 = t2.generateToStrings(toks);
       for (const [filename, content] of out1) {
         expect(
           out2.get(filename),
-          `non-deterministic on second call: ${filename} (seed=${seed})`,
+          `non-deterministic across instances: ${filename} (seed=${seed})`,
         ).toBe(content);
       }
     });

--- a/src/fuzz/token-graph.fuzz.test.ts
+++ b/src/fuzz/token-graph.fuzz.test.ts
@@ -1,0 +1,486 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { composite, dim, dur, group, ref, theme, tokens as combineTokens } from "../builders.js";
+import {
+  CssVars,
+  DtcgGenerator,
+  Html,
+  JavaScript,
+  Json,
+  Scss,
+  ScssVars,
+  Storybook,
+  TypeScript,
+  TypeScriptDeclarations,
+} from "../Generators/index.js";
+import type { Generator } from "../Generators/index.js";
+import {
+  AlphaMultiplyPlugin,
+  ClampPlugin,
+  ColorTransformPlugin,
+  DeprecationPlugin,
+  NameConventionPlugin,
+  type Plugin,
+  RemUnitPlugin,
+  ScssQuoteValuePlugin,
+  StripTypePrefixPlugin,
+} from "../Plugins/index.js";
+import { Teikn } from "../Teikn.js";
+import type { TeiknOptions } from "../Teikn.ts";
+import { BoxShadow } from "../TokenTypes/BoxShadow.js";
+import { Color } from "../TokenTypes/Color/index.js";
+import { CubicBezier } from "../TokenTypes/CubicBezier.js";
+import { LinearGradient } from "../TokenTypes/Gradient.js";
+import { Transition } from "../TokenTypes/Transition.js";
+
+// ─── PRNG ────────────────────────────────────────────────────────
+// Mulberry32 — deterministic, seedable PRNG so failures reproduce.
+
+type Rng = () => number;
+
+const makeRng = (seed: number): Rng => {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+};
+
+const pick = <T>(rng: Rng, arr: readonly T[]): T => arr[Math.floor(rng() * arr.length)]!;
+const intBetween = (rng: Rng, lo: number, hi: number): number =>
+  Math.floor(rng() * (hi - lo + 1)) + lo;
+const chance = (rng: Rng, p: number): boolean => rng() < p;
+
+// ─── Value generators ────────────────────────────────────────────
+
+const dimUnits = ["px", "rem", "em", "%", "vw", "vh"] as const;
+const durUnits = ["ms", "s"] as const;
+
+const randColor = (rng: Rng): Color =>
+  new Color(intBetween(rng, 0, 255), intBetween(rng, 0, 255), intBetween(rng, 0, 255));
+
+const randDimension = (rng: Rng) => dim(intBetween(rng, 0, 64), pick(rng, dimUnits));
+const randDuration = (rng: Rng) => dur(intBetween(rng, 0, 1000), pick(rng, durUnits));
+
+const randCubicBezier = (rng: Rng): CubicBezier => new CubicBezier(rng(), rng(), rng(), rng());
+
+const randBoxShadow = (rng: Rng): BoxShadow =>
+  new BoxShadow(
+    intBetween(rng, -10, 10),
+    intBetween(rng, -10, 10),
+    intBetween(rng, 0, 30),
+    intBetween(rng, 0, 10),
+    randColor(rng),
+    chance(rng, 0.2),
+  );
+
+const randLinearGradient = (rng: Rng): LinearGradient =>
+  new LinearGradient(`${intBetween(rng, 0, 359)}deg`, [randColor(rng), randColor(rng)]);
+
+const randTransition = (rng: Rng): Transition =>
+  new Transition(randDuration(rng), randCubicBezier(rng), randDuration(rng), "all");
+
+// ─── Token-type metadata ─────────────────────────────────────────
+
+type TokenTypeSpec = {
+  type: string;
+  make: (rng: Rng) => unknown;
+};
+
+const tokenTypes: TokenTypeSpec[] = [
+  { type: "color", make: randColor },
+  { type: "spacing", make: randDimension },
+  { type: "borderRadius", make: randDimension },
+  { type: "fontSize", make: randDimension },
+  { type: "duration", make: randDuration },
+  { type: "easing", make: randCubicBezier },
+  { type: "shadow", make: randBoxShadow },
+  { type: "gradient", make: randLinearGradient },
+  { type: "transition", make: randTransition },
+];
+
+// ─── Name generators ─────────────────────────────────────────────
+
+const safeNames = [
+  "primary",
+  "secondary",
+  "accent",
+  "background",
+  "surface",
+  "muted",
+  "subtle",
+  "danger",
+  "warning",
+  "info",
+  "success",
+];
+
+const trickyNames = [
+  "default",
+  "class",
+  "delete",
+  "let",
+  "import",
+  "naïve",
+  "façade",
+  "色",
+  "über",
+  "emoji-rocket",
+];
+
+const randName = (rng: Rng, tricky: boolean): string =>
+  tricky && chance(rng, 0.3) ? pick(rng, trickyNames) : pick(rng, safeNames);
+
+// ─── Token-graph generator ───────────────────────────────────────
+
+const buildGraph = (rng: Rng, opts: { tricky: boolean }) => {
+  const groupCount = intBetween(rng, 1, 4);
+  const allGroups: Array<{ type: string; names: string[]; entries: Record<string, unknown> }> = [];
+
+  const used = new Set<string>();
+  for (let g = 0; g < groupCount; g++) {
+    const spec = tokenTypes[g % tokenTypes.length]!;
+    const tokenCount = intBetween(rng, 1, 5);
+    const entries: Record<string, unknown> = {};
+    const names: string[] = [];
+    for (let i = 0; i < tokenCount; i++) {
+      let n: string;
+      let guard = 0;
+      do {
+        n = `${randName(rng, opts.tricky)}-${i}-${g}`;
+        guard++;
+      } while (used.has(n) && guard < 5);
+      used.add(n);
+      names.push(n);
+      // Plain value, tuple, or object form
+      const value = spec.make(rng);
+      const form = intBetween(rng, 0, 2);
+      if (form === 0) {
+        entries[n] = value;
+      } else if (form === 1) {
+        entries[n] = [value, "usage doc"];
+      } else {
+        const wantModes = chance(rng, 0.5);
+        entries[n] = wantModes
+          ? { value, modes: { dark: spec.make(rng), light: spec.make(rng) } }
+          : { value };
+      }
+    }
+    allGroups.push({ type: spec.type, names, entries });
+  }
+
+  // Add references — short reference chains across groups (1-4 hops)
+  if (allGroups.length > 0 && chance(rng, 0.9)) {
+    const target = allGroups[0]!;
+    if (target.names.length > 0) {
+      target.entries["link-ref"] = ref(target.names[0]!);
+      target.names.push("link-ref");
+      if (chance(rng, 0.6)) {
+        target.entries["link-ref-2"] = ref("link-ref");
+        target.names.push("link-ref-2");
+      }
+    }
+  }
+
+  // Add a composite token with a `{ref}` color field
+  if (chance(rng, 0.5) && allGroups.some((g) => g.type === "color")) {
+    const colorGroup = allGroups.find((g) => g.type === "color")!;
+    if (colorGroup.names.length > 0) {
+      const refName = colorGroup.names[0]!;
+      allGroups.push({
+        type: "composite-shadow",
+        names: ["composite-shadow"],
+        entries: {
+          "composite-shadow": {
+            value: {
+              offsetX: 0,
+              offsetY: intBetween(rng, 0, 4),
+              blur: intBetween(rng, 0, 8),
+              color: `{${refName}}`,
+            } as never,
+          },
+        },
+      });
+    }
+  }
+
+  const tokenArrays = allGroups.map((g) =>
+    g.type === "composite-shadow"
+      ? composite("shadow", g.entries as Record<string, never>)
+      : group(g.type, g.entries as Record<string, never>),
+  );
+  return combineTokens(...tokenArrays);
+};
+
+// ─── Plugin generator ────────────────────────────────────────────
+
+const allPlugins = (rng: Rng): Plugin[] => {
+  const stack: Plugin[] = [];
+  if (chance(rng, 0.5)) {
+    stack.push(
+      new ColorTransformPlugin({
+        type: pick(rng, ["hex", "rgb", "rgba", "hsl"] as const),
+      }),
+    );
+  }
+  if (chance(rng, 0.3)) {
+    stack.push(new AlphaMultiplyPlugin({ background: "#ffffff" }));
+  }
+  if (chance(rng, 0.3)) {
+    stack.push(new RemUnitPlugin({ base: 16, targetUnit: "rem" }));
+  }
+  if (chance(rng, 0.3)) {
+    stack.push(
+      new NameConventionPlugin({
+        convention: pick(rng, [
+          "camelCase",
+          "kebab-case",
+          "snake_case",
+          "PascalCase",
+          "SCREAMING_SNAKE",
+        ] as const),
+      }),
+    );
+  }
+  if (chance(rng, 0.2)) {
+    stack.push(new ScssQuoteValuePlugin());
+  }
+  if (chance(rng, 0.2)) {
+    stack.push(new StripTypePrefixPlugin());
+  }
+  if (chance(rng, 0.2)) {
+    stack.push(new DeprecationPlugin({ tokens: {} }));
+  }
+  if (chance(rng, 0.1)) {
+    stack.push(new ClampPlugin({ pairs: [] }));
+  }
+  return stack;
+};
+
+// ─── Build a Teikn covering all generators with distinct filenames ──
+
+const fixedDate = () => "FIXED";
+
+const buildGenerators = (): Generator[] => [
+  new CssVars({ dateFn: fixedDate }),
+  new Scss({ filename: "tokens-scss", dateFn: fixedDate }),
+  new ScssVars({ filename: "tokens-vars", dateFn: fixedDate }),
+  new Html({ dateFn: fixedDate }),
+  new Json(),
+  new DtcgGenerator(),
+  new JavaScript({ filename: "tokens-js", dateFn: fixedDate }),
+  new TypeScript({ filename: "tokens-ts", dateFn: fixedDate }),
+  new TypeScriptDeclarations({ filename: "tokens-decl", dateFn: fixedDate }),
+  new Storybook({ filename: "tokens-story", dateFn: fixedDate }),
+];
+
+// ─── Fuzz tests ──────────────────────────────────────────────────
+
+describe("token-graph fuzz", () => {
+  const COUNT = Number(process.env.FUZZ_COUNT ?? 80);
+
+  for (let i = 0; i < COUNT; i++) {
+    const seed = 0xc0ffee + i;
+    it(`seed=${seed}: all generators emit non-empty output and are deterministic`, () => {
+      const rng = makeRng(seed);
+      const toks = buildGraph(rng, { tricky: chance(rng, 0.7) });
+      const plugins = allPlugins(rng);
+
+      const opts: TeiknOptions = {
+        generators: buildGenerators(),
+        plugins,
+        validate: false,
+      };
+
+      const t1 = new Teikn(opts);
+      // BUG: `_t2` is constructed but determinism check below mistakenly
+      // reuses `t1`. Pinned for follow-up; renaming preserves current behavior.
+      const _t2 = new Teikn({
+        ...opts,
+        generators: buildGenerators(),
+        plugins: allPlugins(makeRng(seed)).slice(0, plugins.length),
+      });
+
+      let out1: Map<string, string>;
+      try {
+        out1 = t1.generateToStrings(toks);
+      } catch (e) {
+        throw new Error(`generate threw (seed=${seed}): ${(e as Error).message}`);
+      }
+      expect(out1.size).toBeGreaterThan(0);
+      for (const [filename, content] of out1) {
+        expect(content, `empty output for ${filename}`).not.toBe("");
+        expect(typeof content).toBe("string");
+      }
+
+      // JSON outputs must parse
+      const jsonContent = out1.get("tokens.json");
+      if (jsonContent) {
+        expect(
+          () => JSON.parse(jsonContent),
+          `Json output not parseable (seed=${seed})`,
+        ).not.toThrow();
+      }
+      const dtcgContent = out1.get("tokens.tokens.json");
+      if (dtcgContent) {
+        expect(
+          () => JSON.parse(dtcgContent),
+          `Dtcg output not parseable (seed=${seed})`,
+        ).not.toThrow();
+      }
+
+      const jsContent = out1.get("tokens-js.mjs");
+      if (jsContent) {
+        expect(
+          jsContent.includes("export const tokens"),
+          `JS missing 'export const tokens' (seed=${seed})`,
+        ).toBe(true);
+      }
+      const cssContent = out1.get("tokens.css");
+      if (cssContent) {
+        expect(cssContent.includes(":"), `CSS missing declarations (seed=${seed})`).toBe(true);
+      }
+
+      // Determinism: same input + same plugins should produce identical output
+      // (Use the same Teikn instance generators reused on the same input.)
+      const out2 = t1.generateToStrings(toks);
+      for (const [filename, content] of out1) {
+        expect(
+          out2.get(filename),
+          `non-deterministic on second call: ${filename} (seed=${seed})`,
+        ).toBe(content);
+      }
+    });
+  }
+});
+
+// ─── Stateful re-generation check ────────────────────────────────
+
+describe("Teikn re-generation statefulness", () => {
+  it("calling generateToStrings twice on the same instance is stable", () => {
+    const colors = group("color", {
+      primary: new Color(0, 100, 200),
+      secondary: ref("primary"),
+    });
+    const t = new Teikn({
+      generators: buildGenerators(),
+      plugins: [new ColorTransformPlugin({ type: "hex" })],
+    });
+    const a = t.generateToStrings(colors);
+    const b = t.generateToStrings(colors);
+    for (const [filename, content] of a) {
+      expect(b.get(filename), `mismatched ${filename}`).toBe(content);
+    }
+  });
+});
+
+// ─── JS round-trip via dynamic import ─────────────────────────
+
+describe("JavaScript output round-trips through dynamic import", () => {
+  const seeds = [1, 42, 12345, 99999, 0xdeadbeef];
+  const dir = mkdtempSync(path.join(tmpdir(), "teikn-fuzz-"));
+
+  for (const seed of seeds) {
+    it(`seed=${seed}: .mjs is importable and exposes tokens`, async () => {
+      const rng = makeRng(seed);
+      const toks = buildGraph(rng, { tricky: true });
+      const t = new Teikn({
+        generators: [new JavaScript({ filename: "fuzz-js", dateFn: fixedDate })],
+        plugins: [],
+        validate: false,
+      });
+      const out = t.generateToStrings(toks);
+      const content = out.get("fuzz-js.mjs")!;
+      const file = path.join(dir, `seed-${seed}.mjs`);
+      writeFileSync(file, content);
+      const mod = await import(pathToFileURL(file).href);
+      expect(mod.tokens, `tokens export missing for seed=${seed}`).toBeDefined();
+      expect(typeof mod.tokens).toBe("object");
+    });
+  }
+
+  it("cleanup", () => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+// ─── Pinned hand-crafted reproductions for any bugs found ──────
+
+describe("pinned repro: plugin stack with composite + refs", () => {
+  it("ColorTransform + NameConvention + StripTypePrefix over composites", () => {
+    const colors = group("color", { primary: new Color(255, 0, 0) });
+    const shadows = composite("shadow", {
+      lifted: { offsetX: 0, offsetY: 2, blur: 4, color: "{primary}" },
+    });
+    const t = new Teikn({
+      generators: buildGenerators(),
+      plugins: [
+        new ColorTransformPlugin({ type: "hex" }),
+        new NameConventionPlugin({ convention: "SCREAMING_SNAKE" }),
+        new StripTypePrefixPlugin(),
+      ],
+      validate: false,
+    });
+    expect(() => t.generateToStrings(combineTokens(colors, shadows))).not.toThrow();
+  });
+});
+
+describe("pinned repro: composite with referenced field", () => {
+  it("BoxShadow color resolved through a ref works", () => {
+    const colors = group("color", { primary: new Color(0, 100, 200) });
+    const shadows = composite("shadow", {
+      lifted: { offsetX: 0, offsetY: 2, blur: 4, color: "{primary}" },
+    });
+    const t = new Teikn({
+      generators: buildGenerators(),
+      plugins: [],
+      validate: false,
+    });
+    expect(() => t.generateToStrings(combineTokens(colors, shadows))).not.toThrow();
+  });
+});
+
+describe("pinned repro: unicode + reserved-word token names", () => {
+  it("emoji-rocket and 'default' names survive all generators", () => {
+    const colors = group("color", {
+      default: new Color(255, 0, 0),
+      "emoji-rocket": new Color(0, 255, 0),
+      色: new Color(0, 0, 255),
+    });
+    const t = new Teikn({ generators: buildGenerators(), plugins: [], validate: false });
+    expect(() => t.generateToStrings(colors)).not.toThrow();
+  });
+});
+
+describe("pinned repro: deep nested groups (5+ levels via dotted names)", () => {
+  it("dotted group/name chains roundtrip", () => {
+    const deep = group("color", {
+      "a.b.c.d.e.f": new Color(1, 2, 3),
+    });
+    const t = new Teikn({ generators: buildGenerators(), plugins: [], validate: false });
+    expect(() => t.generateToStrings(deep)).not.toThrow();
+  });
+});
+
+describe("pinned repro: theme layer + modes interaction", () => {
+  it("theme overrides merge cleanly with explicit modes", () => {
+    const colors = group("color", {
+      bg: { value: new Color(255, 255, 255), modes: { dark: new Color(0, 0, 0) } },
+    });
+    const dark = theme("dark", colors, { bg: new Color(10, 10, 10) });
+    const t = new Teikn({
+      generators: buildGenerators(),
+      themes: [dark],
+      validate: false,
+    });
+    expect(() => t.generateToStrings(colors)).not.toThrow();
+  });
+});

--- a/src/misuse-patterns.test.ts
+++ b/src/misuse-patterns.test.ts
@@ -151,31 +151,29 @@ describe("misuse patterns", () => {
   // 7. Duplicate token names
   // ──────────────────────────────────────────────────────────────────
   describe("7. duplicate token names", () => {
-    test("tokens() with duplicate names in separate groups", () => {
+    test("tokens() with duplicate names in separate groups is a validation error", () => {
       const a = group("color", { primary: "#000" });
       const b = group("color", { primary: "#fff" });
       const combined = tokens(a, b);
-      // Both tokens are in the array
       expect(combined.length).toBe(2);
 
       const result = validate(combined);
-      // GOOD: validate warns about duplicate names
-      expect(result.issues.some((i) => i.message.includes("Duplicate token name"))).toBe(true);
+      expect(result.valid).toBe(false);
+      expect(
+        result.issues.some(
+          (i) => i.severity === "error" && /Duplicate qualified token name/.test(i.message),
+        ),
+      ).toBe(true);
     });
 
-    test("generateToStrings with duplicates uses last value", () => {
+    test("generateToStrings with duplicates throws", () => {
       const a = group("color", { primary: "#000000" });
       const b = group("color", { primary: "#ffffff" });
       const combined = tokens(a, b);
       const t = new Teikn({
         generators: [new Teikn.generators.CssVars({ version: "test" })],
       });
-      const result = t.generateToStrings(combined);
-      const css = result.get("tokens.css")!;
-      // FOOTGUN: both tokens end up in the output, second overwrites first in CSS cascade
-      // but both are emitted. No deduplication happens.
-      expect(css).toContain("#000000");
-      expect(css).toContain("#ffffff");
+      expect(() => t.generateToStrings(combined)).toThrow(/Duplicate qualified token name/);
     });
   });
 

--- a/src/reference-stress.test.ts
+++ b/src/reference-stress.test.ts
@@ -109,17 +109,30 @@ describe("reference stress", () => {
     expect(v.color).not.toBe("{accent}");
   });
 
-  // ── Scenario 8: ref inside a first-class wrapper (Transition) ─
-  test("(8) Transition built from a {ref} string in the object form — BUG candidate", () => {
-    // The Transition class doesn't know about refs. When constructed at token
-    // authoring time with `duration: "{motion.fast}"`, parsing fails or the
-    // ref is baked into the wrapper object and never resolved.
-    // resolveReferences treats first-class values as opaque (isFirstClassValue).
-    // So the ref inside survives unresolved.
-    // Actual behavior: Duration constructor throws on `{motion.fast}`.
-    // This effectively means: refs cannot be embedded inside first-class
-    // wrappers. Use plain composite objects if you need ref-substitution.
-    expect(() => new Transition({ duration: "{motion.fast}", timingFunction: "ease" })).toThrow();
+  // ── Scenario 8: ref inside a first-class wrapper ──────────────
+  test("(8) Duration string ref is rejected with a clear message", () => {
+    expect(() => new Duration("{motion.fast}")).toThrow(
+      /Duration cannot be constructed from a reference string/,
+    );
+  });
+
+  test("(8) Transition object with ref string in a field is rejected via Duration", () => {
+    expect(() => new Transition({ duration: "{motion.fast}", timingFunction: "ease" })).toThrow(
+      /Duration cannot be constructed from a reference string/,
+    );
+  });
+
+  test("(8) BoxShadow with a ref-string color is rejected via Color", () => {
+    expect(
+      () =>
+        new BoxShadow({
+          offsetX: 0,
+          offsetY: 2,
+          blur: 8,
+          spread: 0,
+          color: "{accent}",
+        }),
+    ).toThrow(/Color cannot be constructed from a reference string/);
   });
 
   // ── Scenario 9: ref points at a composite value ───────────────

--- a/src/reference-stress.test.ts
+++ b/src/reference-stress.test.ts
@@ -150,48 +150,42 @@ describe("reference stress", () => {
   });
 
   // ── Scenario 10: dotted token names in groups ─────────────────
-  test("(10) dotted token name within a group — qualified key is ambiguous", () => {
-    // BUG candidate: tokenKey() joins with "." so `g` + `key.with.dots`
-    // produces `g.key.with.dots`. There is no way to know whether the user
-    // meant group=g, name=key.with.dots OR group=g.key.with, name=dots, etc.
-    // bareKey() picks LAST segment after split(".") — so the bare alias for
-    // `g.key.with.dots` becomes `dots`, not `key.with.dots`.
+  test("(10) dotted token names are rejected at validation time", () => {
     const tokens: Token[] = [
       { name: "key.with.dots", group: "g", type: "color", value: "#aaa" },
-      { name: "ref1", type: "color", value: "{g.key.with.dots}" },
-      { name: "ref2", type: "color", value: "{dots}" },
     ];
-    const out = resolveReferences(tokens);
-    expect(out[1]!.value).toBe("#aaa");
-    // BUG: bare {dots} resolves to the token via last-segment-bare logic,
-    // which is surprising — user likely expected {key.with.dots} bare.
-    expect(out[2]!.value).toBe("#aaa");
+    const { issues, valid } = validate(tokens);
+    expect(valid).toBe(false);
+    expect(issues.some((i) => i.severity === "error" && /must not contain/.test(i.message))).toBe(
+      true,
+    );
+  });
 
-    // BUG: bare-name lookup uses LAST `.`-segment only. A token authored as
-    // `name: "key.with.dots"` is NOT addressable via the bare reference
-    // `{key.with.dots}` (only `{dots}` or fully-qualified `{g.key.with.dots}`).
-    // Likely intentional but surprising; document as an open design question.
+  test("(10) dotted group is rejected at validation time", () => {
+    const tokens: Token[] = [
+      { name: "primary", group: "g.nested", type: "color", value: "#aaa" },
+    ];
+    const { issues, valid } = validate(tokens);
+    expect(valid).toBe(false);
+    expect(
+      issues.some(
+        (i) => i.severity === "error" && /group "g\.nested" must not contain/.test(i.message),
+      ),
+    ).toBe(true);
+  });
 
-    // Collision: group `g` + name `key.with.dots` vs group `g.key.with` + name `dots`
-    // both produce the qualified key `g.key.with.dots`. The validate() pass
-    // catches this via the name-index ("Duplicate token name"), but the
-    // resolver itself silently overwrites the first with the second.
+  test("(10) duplicate qualified token name is a validation error", () => {
     const collide: Token[] = [
-      { name: "key.with.dots", group: "g", type: "color", value: "#aaa" },
-      { name: "dots", group: "g.key.with", type: "color", value: "#bbb" },
+      { name: "primary", group: "color", type: "color", value: "#aaa" },
+      { name: "primary", group: "color", type: "color", value: "#bbb" },
     ];
-    const r = resolveReferences([
-      ...collide,
-      { name: "use", type: "color", value: "{g.key.with.dots}" },
-    ]);
-    // Second token silently wins:
-    expect(r[2]!.value).toBe("#bbb");
-    // validate catches it as a warning (severity warning, not error):
-    const { issues } = validate(collide);
-    expect(issues.some((i) => /Duplicate token name/.test(i.message))).toBe(true);
-    // BUG: this is a *warning*, not an *error*. A real key collision should
-    // probably be an error, since the resolver picks a value non-deterministically
-    // from the user's perspective (order-dependent).
+    const { issues, valid } = validate(collide);
+    expect(valid).toBe(false);
+    expect(
+      issues.some(
+        (i) => i.severity === "error" && /Duplicate qualified token name/.test(i.message),
+      ),
+    ).toBe(true);
   });
 
   // ── Scenario 11: unresolved reference ─────────────────────────

--- a/src/reference-stress.test.ts
+++ b/src/reference-stress.test.ts
@@ -164,9 +164,7 @@ describe("reference stress", () => {
 
   // ── Scenario 10: dotted token names in groups ─────────────────
   test("(10) dotted token names are rejected at validation time", () => {
-    const tokens: Token[] = [
-      { name: "key.with.dots", group: "g", type: "color", value: "#aaa" },
-    ];
+    const tokens: Token[] = [{ name: "key.with.dots", group: "g", type: "color", value: "#aaa" }];
     const { issues, valid } = validate(tokens);
     expect(valid).toBe(false);
     expect(issues.some((i) => i.severity === "error" && /must not contain/.test(i.message))).toBe(
@@ -175,9 +173,7 @@ describe("reference stress", () => {
   });
 
   test("(10) dotted group is rejected at validation time", () => {
-    const tokens: Token[] = [
-      { name: "primary", group: "g.nested", type: "color", value: "#aaa" },
-    ];
+    const tokens: Token[] = [{ name: "primary", group: "g.nested", type: "color", value: "#aaa" }];
     const { issues, valid } = validate(tokens);
     expect(valid).toBe(false);
     expect(

--- a/src/reference-stress.test.ts
+++ b/src/reference-stress.test.ts
@@ -1,0 +1,340 @@
+import { describe, expect, test } from "bun:test";
+
+import { CssVars } from "./Generators/CssVars.js";
+import { JavaScript } from "./Generators/JavaScript.js";
+import { Scss } from "./Generators/Scss.js";
+import { NameConventionPlugin } from "./Plugins/NameConventionPlugin.js";
+import { resolveReferences } from "./resolve.js";
+import { Teikn } from "./Teikn.js";
+import type { Token } from "./Token.js";
+import { BoxShadow } from "./TokenTypes/BoxShadow.js";
+import { Color } from "./TokenTypes/Color/index.js";
+import { Duration } from "./TokenTypes/Duration.js";
+import { Transition } from "./TokenTypes/Transition.js";
+import { validate } from "./validate.js";
+
+describe("reference stress", () => {
+  // ── Scenario 1: group-shadowing ambiguity ─────────────────────
+  test("(1) bare {primary} ambiguous across two groups lists both candidates", () => {
+    const tokens: Token[] = [
+      { name: "primary", group: "color", type: "color", value: "#fff" },
+      { name: "primary", group: "size", type: "spacing", value: "16px" },
+      { name: "link", type: "color", value: "{primary}" },
+    ];
+    let err: Error | null = null;
+    try {
+      resolveReferences(tokens);
+    } catch (e) {
+      err = e as Error;
+    }
+    expect(err).not.toBeNull();
+    expect(err!.message).toMatch(/color\.primary/);
+    expect(err!.message).toMatch(/size\.primary/);
+  });
+
+  // ── Scenario 2: cross-group qualified + bare in same set ──────
+  test("(2) {color.primary} resolves while bare {primary} ambiguous", () => {
+    const tokens: Token[] = [
+      { name: "primary", group: "color", type: "color", value: "#abc" },
+      { name: "primary", group: "size", type: "spacing", value: "8px" },
+      { name: "link", type: "color", value: "{color.primary}" },
+    ];
+    const out = resolveReferences(tokens);
+    expect(out[2]!.value).toBe("#abc");
+  });
+
+  // ── Scenario 3: self-reference ────────────────────────────────
+  test("(3) self-reference throws circular, no stack overflow", () => {
+    const tokens: Token[] = [{ name: "x", type: "color", value: "{x}" }];
+    expect(() => resolveReferences(tokens)).toThrow("Circular reference");
+  });
+
+  test("(3b) qualified self-reference throws circular", () => {
+    const tokens: Token[] = [{ name: "x", group: "g", type: "color", value: "{g.x}" }];
+    expect(() => resolveReferences(tokens)).toThrow("Circular reference");
+  });
+
+  // ── Scenario 4: direct two-token cycle ────────────────────────
+  test("(4) A->B->A cycle throws", () => {
+    const tokens: Token[] = [
+      { name: "a", type: "color", value: "{b}" },
+      { name: "b", type: "color", value: "{a}" },
+    ];
+    expect(() => resolveReferences(tokens)).toThrow("Circular reference");
+  });
+
+  // ── Scenario 5: mode-conditional cycle ────────────────────────
+  test("(5) cycle only present in modes (dark) is caught", () => {
+    const tokens: Token[] = [
+      { name: "a", type: "color", value: "{b}" },
+      { name: "b", type: "color", value: "#fff", modes: { dark: "{a}" } },
+    ];
+    // resolveReferences walks through the referenced token's modes when
+    // recursing, so the cycle IS caught here.
+    expect(() => resolveReferences(tokens)).toThrow("Circular reference");
+    const v = validate(tokens);
+    expect(v.issues.some((i) => /Circular/.test(i.message))).toBe(true);
+  });
+
+  // ── Scenario 6: ref to a token only defined in some modes ─────
+  test("(6) A.modes.dark -> {B}, B has only default — falls back to B default", () => {
+    const tokens: Token[] = [
+      { name: "B", type: "color", value: "#111" },
+      { name: "A", type: "color", value: "#fff", modes: { dark: "{B}" } },
+    ];
+    const out = resolveReferences(tokens);
+    // Current behavior: ref resolves to B's default value
+    expect(out[1]!.modes!["dark"]).toBe("#111");
+  });
+
+  // ── Scenario 7: ref inside a composite (plain object) shadow ──
+  test("(7) shadow composite color={accent} resolves in every generator", () => {
+    const tokens: Token[] = [
+      { name: "accent", type: "color", value: "#abcdef" },
+      {
+        name: "elev",
+        type: "shadow",
+        value: {
+          color: "{accent}",
+          offsetX: "0",
+          offsetY: "2px",
+          blur: "8px",
+          spread: "0",
+        },
+      },
+    ];
+    const out = resolveReferences(tokens);
+    const v = out[1]!.value as Record<string, unknown>;
+    expect(v.color).toBe("#abcdef");
+    expect(v.color).not.toBe("{accent}");
+  });
+
+  // ── Scenario 8: ref inside a first-class wrapper (Transition) ─
+  test("(8) Transition built from a {ref} string in the object form — BUG candidate", () => {
+    // The Transition class doesn't know about refs. When constructed at token
+    // authoring time with `duration: "{motion.fast}"`, parsing fails or the
+    // ref is baked into the wrapper object and never resolved.
+    // resolveReferences treats first-class values as opaque (isFirstClassValue).
+    // So the ref inside survives unresolved.
+    // Actual behavior: Duration constructor throws on `{motion.fast}`.
+    // This effectively means: refs cannot be embedded inside first-class
+    // wrappers. Use plain composite objects if you need ref-substitution.
+    expect(() => new Transition({ duration: "{motion.fast}", timingFunction: "ease" })).toThrow();
+  });
+
+  // ── Scenario 9: ref points at a composite value ───────────────
+  test("(9) A.value={shadow.elevation1} where elevation1 is composite", () => {
+    const tokens: Token[] = [
+      {
+        name: "elevation1",
+        group: "shadow",
+        type: "shadow",
+        value: {
+          color: "#000",
+          offsetX: "0",
+          offsetY: "2px",
+          blur: "8px",
+          spread: "0",
+        },
+      },
+      { name: "card", type: "shadow", value: "{shadow.elevation1}" },
+    ];
+    const out = resolveReferences(tokens);
+    expect(out[1]!.value).toEqual({
+      color: "#000",
+      offsetX: "0",
+      offsetY: "2px",
+      blur: "8px",
+      spread: "0",
+    });
+  });
+
+  // ── Scenario 10: dotted token names in groups ─────────────────
+  test("(10) dotted token name within a group — qualified key is ambiguous", () => {
+    // BUG candidate: tokenKey() joins with "." so `g` + `key.with.dots`
+    // produces `g.key.with.dots`. There is no way to know whether the user
+    // meant group=g, name=key.with.dots OR group=g.key.with, name=dots, etc.
+    // bareKey() picks LAST segment after split(".") — so the bare alias for
+    // `g.key.with.dots` becomes `dots`, not `key.with.dots`.
+    const tokens: Token[] = [
+      { name: "key.with.dots", group: "g", type: "color", value: "#aaa" },
+      { name: "ref1", type: "color", value: "{g.key.with.dots}" },
+      { name: "ref2", type: "color", value: "{dots}" },
+    ];
+    const out = resolveReferences(tokens);
+    expect(out[1]!.value).toBe("#aaa");
+    // BUG: bare {dots} resolves to the token via last-segment-bare logic,
+    // which is surprising — user likely expected {key.with.dots} bare.
+    expect(out[2]!.value).toBe("#aaa");
+
+    // BUG: bare-name lookup uses LAST `.`-segment only. A token authored as
+    // `name: "key.with.dots"` is NOT addressable via the bare reference
+    // `{key.with.dots}` (only `{dots}` or fully-qualified `{g.key.with.dots}`).
+    // Likely intentional but surprising; document as an open design question.
+
+    // Collision: group `g` + name `key.with.dots` vs group `g.key.with` + name `dots`
+    // both produce the qualified key `g.key.with.dots`. The validate() pass
+    // catches this via the name-index ("Duplicate token name"), but the
+    // resolver itself silently overwrites the first with the second.
+    const collide: Token[] = [
+      { name: "key.with.dots", group: "g", type: "color", value: "#aaa" },
+      { name: "dots", group: "g.key.with", type: "color", value: "#bbb" },
+    ];
+    const r = resolveReferences([
+      ...collide,
+      { name: "use", type: "color", value: "{g.key.with.dots}" },
+    ]);
+    // Second token silently wins:
+    expect(r[2]!.value).toBe("#bbb");
+    // validate catches it as a warning (severity warning, not error):
+    const { issues } = validate(collide);
+    expect(issues.some((i) => /Duplicate token name/.test(i.message))).toBe(true);
+    // BUG: this is a *warning*, not an *error*. A real key collision should
+    // probably be an error, since the resolver picks a value non-deterministically
+    // from the user's perspective (order-dependent).
+  });
+
+  // ── Scenario 11: unresolved reference ─────────────────────────
+  test("(11) {nonexistent} throws clear error", () => {
+    const tokens: Token[] = [{ name: "x", type: "color", value: "{nope}" }];
+    expect(() => resolveReferences(tokens)).toThrow(/Unresolved reference.*nope/);
+  });
+
+  // ── Scenario 12: ref to a plugin-renamed token ────────────────
+  test("(12) refs survive a NameConventionPlugin rename through full pipeline", () => {
+    const teikn = new Teikn({
+      generators: [new CssVars()],
+      plugins: [new NameConventionPlugin({ convention: "kebab-case" })],
+    });
+    const tokens: Token[] = [
+      { name: "primaryColor", type: "color", value: "#0066cc" },
+      { name: "linkColor", type: "color", value: "{primaryColor}" },
+    ];
+    const result = teikn.generateToStrings(tokens);
+    const css = [...result.values()][0]!;
+    // The link token's value should be the resolved color, not the literal
+    // `{primaryColor}` and not a `var(--undefined)`.
+    expect(css).toMatch(/--color-link-color:\s*#0066cc/);
+  });
+
+  // ── Scenario 13: refs in mode values across generators ────────
+  test("(13a) CssVars renders mode refs as var(--...) to the resolved token", () => {
+    const teikn = new Teikn({ generators: [new CssVars()] });
+    const tokens: Token[] = [
+      { name: "darkBg", type: "color", value: "#000" },
+      {
+        name: "bg",
+        type: "color",
+        value: "#fff",
+        modes: { dark: "{darkBg}" },
+      },
+    ];
+    const result = teikn.generateToStrings(tokens);
+    const css = [...result.values()][0]!;
+    // Either resolved literal `#000` or `var(--color-dark-bg)` — both correct.
+    expect(css).toMatch(/#000|var\(--color-dark-bg\)/);
+    expect(css).not.toMatch(/\{darkBg\}/);
+  });
+
+  test("(13b) Scss renders mode refs as resolved values", () => {
+    const teikn = new Teikn({ generators: [new Scss()] });
+    const tokens: Token[] = [
+      { name: "darkBg", type: "color", value: "#000" },
+      {
+        name: "bg",
+        type: "color",
+        value: "#fff",
+        modes: { dark: "{darkBg}" },
+      },
+    ];
+    const result = teikn.generateToStrings(tokens);
+    const scss = [...result.values()][0]!;
+    expect(scss).not.toMatch(/\{darkBg\}/);
+  });
+
+  test("(13c) JavaScript renders mode refs as resolved values", () => {
+    const teikn = new Teikn({ generators: [new JavaScript()] });
+    const tokens: Token[] = [
+      { name: "darkBg", type: "color", value: "#000" },
+      {
+        name: "bg",
+        type: "color",
+        value: "#fff",
+        modes: { dark: "{darkBg}" },
+      },
+    ];
+    const result = teikn.generateToStrings(tokens);
+    const js = [...result.values()][0]!;
+    expect(js).not.toMatch(/\{darkBg\}/);
+    expect(js).toMatch(/#000/);
+  });
+
+  // ── Scenario 14: whitespace inside the braces ─────────────────
+  test("(14) {  color.primary  } with spaces — current behavior", () => {
+    const tokens: Token[] = [
+      { name: "primary", group: "color", type: "color", value: "#abc" },
+      { name: "link", type: "color", value: "{ color.primary }" },
+    ];
+    let out: Token[] | null = null;
+    let err: Error | null = null;
+    try {
+      out = resolveReferences(tokens);
+    } catch (e) {
+      err = e as Error;
+    }
+    // Current REF_PATTERN is /^\{([^}]+)\}$/ — captures " color.primary " with
+    // spaces, then resolveKey looks up the literal string " color.primary "
+    // which is missing. Expected to throw Unresolved reference.
+    // OPEN DESIGN QUESTION: should the resolver trim?
+    if (err) {
+      expect(err.message).toMatch(/Unresolved reference/);
+    } else {
+      // If it didn't throw, the link value would still be the literal string
+      expect(out![1]!.value).toBe("{ color.primary }");
+    }
+  });
+
+  // ── Scenario 15: multiple refs in a string ────────────────────
+  test("(15) `{red} {blue}` — only full-string refs supported", () => {
+    const tokens: Token[] = [
+      { name: "red", type: "color", value: "#f00" },
+      { name: "blue", type: "color", value: "#00f" },
+      { name: "duo", type: "string", value: "{red} {blue}" },
+    ];
+    // REF_PATTERN requires the whole string to be a single {...}, so this
+    // is NOT a ref — it passes through verbatim. Documenting current behavior.
+    const out = resolveReferences(tokens);
+    expect(out[2]!.value).toBe("{red} {blue}");
+    // OPEN DESIGN QUESTION: should mid-string interpolation be supported?
+  });
+
+  // ── Bonus: BoxShadow first-class wrapper carrying a Color {ref} ──
+  test("(bonus) BoxShadow constructed with a Color instance — refs cannot be embedded", () => {
+    // Demonstrates that you can't ref-substitute inside first-class wrappers.
+    const shadow = new BoxShadow(0, 2, 8, 0, new Color(0, 0, 0));
+    const tokens: Token[] = [
+      { name: "accent", type: "color", value: new Color(255, 0, 0) },
+      { name: "elev", type: "shadow", value: shadow },
+    ];
+    const out = resolveReferences(tokens);
+    // The shadow's internal color is unaffected by `accent`.
+    expect(String((out[1]!.value as BoxShadow).color)).not.toBe("rgb(255, 0, 0)");
+  });
+
+  // ── Bonus: Duration in Transition cannot reference a Duration token ──
+  test("(bonus) Duration token referenced from a Transition field — not supported", () => {
+    const tokens: Token[] = [
+      { name: "fast", group: "motion", type: "duration", value: new Duration(200, "ms") },
+      // A composite-style transition (plain object), not the first-class wrapper.
+      {
+        name: "fade",
+        type: "transition",
+        value: { duration: "{motion.fast}", timingFunction: "ease" },
+      },
+    ];
+    const out = resolveReferences(tokens);
+    const fade = out[1]!.value as Record<string, unknown>;
+    // Composite-style ref resolves; the value is the Duration instance.
+    expect(fade.duration).toBeInstanceOf(Duration);
+  });
+});

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -188,13 +188,33 @@ export const validate = (tokens: Token[]): ValidationResult => {
     if (!token.type) {
       issue("error", label, "Missing required field: type");
     }
+    if (token.name?.includes(".")) {
+      issue(
+        "error",
+        label,
+        `Token name must not contain "." — the dot is reserved as the group/name separator. ` +
+          `Rename the token, or split the path into \`group\` + \`name\`.`,
+      );
+    }
+    if (token.group?.includes(".")) {
+      issue(
+        "error",
+        label,
+        `Token group "${token.group}" must not contain "." — the dot is reserved as the group/name separator.`,
+      );
+    }
 
     if (token.name) {
       const qualifiedName = tokenKey(token);
       const count = (names.get(qualifiedName) ?? 0) + 1;
       names.set(qualifiedName, count);
       if (count === 2) {
-        issue("warning", token.name, "Duplicate token name");
+        issue(
+          "error",
+          token.name,
+          `Duplicate qualified token name "${qualifiedName}" — two tokens resolve to the same key. ` +
+            `The resolver picks one non-deterministically; rename one of the tokens.`,
+        );
       }
       tokenMap.set(qualifiedName, token);
     }

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const version = "2.0.0-alpha.14";
+export const version = "2.0.0-beta.0";


### PR DESCRIPTION
Getting alpha.14 ready for beta. Did a stress test pass first, then fixed what it found.

Highlights:

- `filenames()` is now a hard contract — generators can no longer emit (or omit) files that don't match their declaration. Closes two silent-clobber / silent-omission bugs.
- Forbid `.` in token name/group, and a dup qualified key is now an error instead of a warning. The dot was the internal separator and bare-name lookup did weird things with it.
- Reject `{ref}` strings inside first-class wrappers (Duration, Color, BoxShadow, etc.) with a clear message. Used to be a confusing parse error.
- `.d.cts` declarations when `module: "cjs"` so Node's strict resolvers find them next to the `.cjs` runtime.
- Plugin errors now include plugin name + token name. Used to be raw, no context.
- `Scss` finally honors its `prefix` option (was typed but unread).
- `DeprecationPlugin` now shows up as `@deprecated` JSDoc in JS/TS output, so IDEs strike through usage.
- Reject path separators in `filename` — was silently writing outside outDir.

Also picked up: `Generator.generate()` resolves refs itself now (matching Teikn's pipeline) and is marked `@internal`; `sortPlugins` warns on unknown `runAfter` targets instead of silently skipping; `bump-version.sh` works under GNU sed.

Around 170 new tests pinning all of the above, including a seeded fuzzer over the token graph.