### PR TITLE
Drop wall-clock date from generated headers

### DIFF
--- a/src/Generators/CssVars.ts
+++ b/src/Generators/CssVars.ts
@@ -2,7 +2,6 @@ import { EOL } from "node:os";
 
 import { kebabCase } from "../string-utils.js";
 import type { Token, TokenValue } from "../Token.js";
-import { getDate } from "../utils.js";
 import type { GeneratorInfo, GeneratorOptions } from "./Generator.js";
 import { Generator } from "./Generator.js";
 import type { PrefixOptions } from "./prefix-utils.js";
@@ -12,7 +11,6 @@ import { cssValue, stringifyWithRefs } from "./value-serializers.js";
 const defaultOptions = {
   ext: "css",
   nameTransformer: kebabCase,
-  dateFn: getDate,
 };
 
 export type ModeSelector = string | { atRule: string; selector?: string };

--- a/src/Generators/Html.ts
+++ b/src/Generators/Html.ts
@@ -30,14 +30,12 @@ import {
   isTypographyType,
   isZLayerType,
 } from "../type-classifiers.js";
-import { getDate } from "../utils.js";
 import type { GeneratorOptions } from "./Generator.js";
 import { Generator } from "./Generator.js";
 
 const defaultOptions = {
   ext: "html",
   nameTransformer: kebabCase,
-  dateFn: getDate,
 };
 
 export type HtmlOpts = {

--- a/src/Generators/JavaScript.ts
+++ b/src/Generators/JavaScript.ts
@@ -2,7 +2,6 @@ import { EOL } from "node:os";
 
 import { camelCase, deriveShortName } from "../string-utils.js";
 import type { Token } from "../Token.js";
-import { getDate } from "../utils.js";
 import type { GeneratorInfo, GeneratorOptions } from "./Generator.js";
 import { Generator } from "./Generator.js";
 import { maybeQuote, quoteKey } from "./value-serializers.js";
@@ -38,7 +37,6 @@ export class JavaScript extends Generator<JavaScriptOpts> {
     }
     super({
       nameTransformer: camelCase,
-      dateFn: getDate,
       module: moduleKind,
       ext: defaultExt(moduleKind),
       ...options,

--- a/src/Generators/Scss.ts
+++ b/src/Generators/Scss.ts
@@ -3,7 +3,6 @@ import { EOL } from "node:os";
 import type { Plugin } from "../Plugins/index.js";
 import { camelCase, deriveShortName, kebabCase } from "../string-utils.js";
 import type { Token } from "../Token.js";
-import { getDate } from "../utils.js";
 import type { GeneratorInfo, GeneratorOptions } from "./Generator.js";
 import { Generator } from "./Generator.js";
 import type { PrefixOptions } from "./prefix-utils.js";
@@ -13,7 +12,6 @@ import { cssMapValue } from "./value-serializers.js";
 const defaultOptions = {
   ext: "scss",
   nameTransformer: kebabCase,
-  dateFn: getDate,
 };
 
 export type ScssOpts = {

--- a/src/Generators/Storybook.ts
+++ b/src/Generators/Storybook.ts
@@ -25,7 +25,6 @@ import {
   isTypographyType,
   isZLayerType,
 } from "../type-classifiers.js";
-import { getDate } from "../utils.js";
 import type { GeneratorInfo, GeneratorOptions } from "./Generator.js";
 import { Generator } from "./Generator.js";
 import { JavaScript } from "./JavaScript.js";
@@ -36,7 +35,6 @@ import { TypeScript } from "./TypeScript.js";
 const defaultOptions = {
   ext: "stories.tsx",
   nameTransformer: camelCase,
-  dateFn: getDate,
   storyTitle: "Design Tokens",
 };
 
@@ -183,16 +181,19 @@ export class Storybook extends Generator<StorybookOpts> {
 
   override header(): string {
     const { dateFn } = this.options;
+    const date = dateFn ? dateFn() : null;
 
     return [
       `/**`,
       ` * ${this.signature()}`,
-      ` * Generated ${dateFn!()}`,
+      date ? ` * Generated ${date}` : null,
       ` *`,
       ` * Storybook stories for design tokens`,
       ` * This file is generated — do not edit manually`,
       ` */`,
-    ].join(EOL);
+    ]
+      .filter(Boolean)
+      .join(EOL);
   }
 
   override footer(): string | null {

--- a/src/Generators/TypeScript.ts
+++ b/src/Generators/TypeScript.ts
@@ -1,7 +1,6 @@
 import type { Plugin } from "../Plugins/index.js";
 import { camelCase } from "../string-utils.js";
 import type { Token } from "../Token.js";
-import { getDate } from "../utils.js";
 import type { GeneratorInfo, GeneratorOptions } from "./Generator.js";
 import { Generator } from "./Generator.js";
 import type { JavaScriptModule } from "./JavaScript.js";
@@ -28,7 +27,6 @@ const defaultOptions = {
   // and `generateFiles()` are overridden to enumerate the real outputs.
   ext: "d.ts",
   nameTransformer: camelCase,
-  dateFn: getDate,
 };
 
 /**

--- a/src/Generators/TypeScriptDeclarations.ts
+++ b/src/Generators/TypeScriptDeclarations.ts
@@ -3,7 +3,6 @@ import { EOL } from "node:os";
 import { camelCase, deriveShortName } from "../string-utils.js";
 import type { Token } from "../Token.js";
 import { isFirstClassValue } from "../type-classifiers.js";
-import { getDate } from "../utils.js";
 import type { GeneratorInfo, GeneratorOptions } from "./Generator.js";
 import { Generator } from "./Generator.js";
 import type { JavaScriptModule } from "./JavaScript.js";
@@ -44,7 +43,6 @@ const toTypeAnnotation = (value: unknown, loose: boolean): string => {
 const defaultOptions = {
   ext: "d.ts",
   nameTransformer: camelCase,
-  dateFn: getDate,
 };
 
 export type TypeScriptDeclarationsOpts = {


### PR DESCRIPTION
Every CI run was producing diffs in checked-in generated files just because seconds passed. Real changes hide in that noise, and snapshot tests have to pin `dateFn` to stay deterministic.

Dropping `dateFn: getDate` as the default for the seven generators that had it. The signature/version stamp stays — that's the part that's actually useful and doesn't change between runs.

`dateFn` is still an option, and `getDate` is still exported, for anyone who wants to opt back in.

No snapshot churn — existing snapshots already pinned the date.