### PR TITLE
Fix SCSS lint issues in generated output

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "prepublishOnly": "tsc",
     "test": "bun test",
     "test:node": "vitest run",
+    "test:update": "bun test --update-snapshots && vitest run --update",
     "storybook": "storybook dev -p 6006",
     "generate-example": "bun example/example-usage.ts"
   },

--- a/src/Generators/CssVars.vitest.snap
+++ b/src/Generators/CssVars.vitest.snap
@@ -14,7 +14,8 @@ exports[`CssVars Generator tests > It generates the token set 1`] = `
   --primary: aliceblue;
   /* the secondary branding color */
   --secondary: rgb(102, 205, 170);
-}"
+}
+"
 `;
 
 exports[`CssVars Generator tests > It generates themed tokens with modes 1`] = `
@@ -32,7 +33,8 @@ exports[`CssVars Generator tests > It generates themed tokens with modes 1`] = `
 [data-theme="dark"] {
   --bg: #1a1a1a;
   --text: #eeeeee;
-}"
+}
+"
 `;
 
 exports[`CssVars Generator tests > modeSelectors handles mix of selectors and at-rules 1`] = `
@@ -54,7 +56,8 @@ exports[`CssVars Generator tests > modeSelectors handles mix of selectors and at
 
 .high-contrast {
   --bg: #000000;
-}"
+}
+"
 `;
 
 exports[`CssVars Generator tests > modeSelectors object form uses custom selector inside at-rule 1`] = `
@@ -72,7 +75,8 @@ exports[`CssVars Generator tests > modeSelectors object form uses custom selecto
   .app {
     --bg: #1a1a1a;
   }
-}"
+}
+"
 `;
 
 exports[`CssVars Generator tests > modeSelectors wraps at-rule strings in :root 1`] = `
@@ -90,5 +94,6 @@ exports[`CssVars Generator tests > modeSelectors wraps at-rule strings in :root 
   :root {
     --bg: #1a1a1a;
   }
-}"
+}
+"
 `;

--- a/src/Generators/Dtcg.vitest.snap
+++ b/src/Generators/Dtcg.vitest.snap
@@ -64,5 +64,6 @@ exports[`DtcgGenerator tests > snapshot test with standard token set 1`] = `
     },
     "$type": "number"
   }
-}"
+}
+"
 `;

--- a/src/Generators/Generator.test.ts
+++ b/src/Generators/Generator.test.ts
@@ -96,7 +96,7 @@ describe("Generator multi-file emission contract", () => {
   test("default generateFiles() returns a single-entry map keyed by this.file", () => {
     const files = new SingleFile().generateFiles([]);
     expect([...files.keys()]).toEqual(["tokens.txt"]);
-    expect(files.get("tokens.txt")).toBe("body");
+    expect(files.get("tokens.txt")).toBe("body\n");
   });
 
   test("multi-file generators can report multiple filenames", () => {

--- a/src/Generators/Generator.ts
+++ b/src/Generators/Generator.ts
@@ -330,7 +330,7 @@ export abstract class Generator<Opts extends GeneratorOptions = GeneratorOptions
     return [this.header(), this.combinator(this.prepareTokens(resolved, plugins)), this.footer()]
       .filter(Boolean)
       .join(EOL)
-      .trim();
+      .trim() + EOL;
   }
 
   /**

--- a/src/Generators/Generator.ts
+++ b/src/Generators/Generator.ts
@@ -327,10 +327,12 @@ export abstract class Generator<Opts extends GeneratorOptions = GeneratorOptions
    */
   generate(tokens: Token[], plugins: Plugin[] = []): string {
     const resolved = resolveReferences(tokens);
-    return [this.header(), this.combinator(this.prepareTokens(resolved, plugins)), this.footer()]
-      .filter(Boolean)
-      .join(EOL)
-      .trim() + EOL;
+    return (
+      [this.header(), this.combinator(this.prepareTokens(resolved, plugins)), this.footer()]
+        .filter(Boolean)
+        .join(EOL)
+        .trim() + EOL
+    );
   }
 
   /**

--- a/src/Generators/Html.vitest.snap
+++ b/src/Generators/Html.vitest.snap
@@ -348,5 +348,6 @@ section h2{font-size:1.25rem;font-weight:600;margin-bottom:1rem;padding-bottom:0
   }
 });</script>
 </body>
-</html>"
+</html>
+"
 `;

--- a/src/Generators/JavaScript.vitest.snap
+++ b/src/Generators/JavaScript.vitest.snap
@@ -38,7 +38,8 @@ export const spacing = (name) => {
   return _spacing[name];
 };
 
-export default tokens;"
+export default tokens;
+"
 `;
 
 exports[`JavaScript generator (ESM default) > it generates tokens as an ES module by default 1`] = `
@@ -66,5 +67,6 @@ export const tokens = {
   secondary: 'rgb(102, 205, 170)',
 };
 
-export default tokens;"
+export default tokens;
+"
 `;

--- a/src/Generators/Json.vitest.snap
+++ b/src/Generators/Json.vitest.snap
@@ -17,5 +17,6 @@ exports[`JSONGenerator tests > It generates the token set 1`] = `
     "usage": "the secondary branding color",
     "value": "rgb(102, 205, 170)"
   }
-}"
+}
+"
 `;

--- a/src/Generators/Scss.ts
+++ b/src/Generators/Scss.ts
@@ -96,9 +96,10 @@ export class Scss extends Generator<ScssOpts> {
     return [
       `/// Use "get-token" to access tokens by name`,
       `@function get-token($name) {`,
-      `  @if (not map.has-key($token-values, $name)) {`,
+      `  @if not map.has-key($token-values, $name) {`,
       `    @error "Token '#{$name}' does not exist.";`,
       `  }`,
+      ``,
       `  @return map.get($token-values, $name);`,
       `}`,
     ].join(EOL);
@@ -129,6 +130,7 @@ export class Scss extends Generator<ScssOpts> {
           `  @if not map.has-key($${groupKebab}-values, $name) {`,
           `    @error "Unknown ${groupKebab} token '#{$name}'. Available: #{map.keys($${groupKebab}-values)}";`,
           `  }`,
+          ``,
           `  @return map.get($${groupKebab}-values, $name);`,
           `}`,
         ].join(EOL);
@@ -143,6 +145,6 @@ export class Scss extends Generator<ScssOpts> {
     if (!groupBlocks) {
       return base;
     }
-    return [base, "", groupBlocks].join(EOL).trim();
+    return [base.trimEnd(), "", groupBlocks].join(EOL).trim() + EOL;
   }
 }

--- a/src/Generators/Scss.vitest.snap
+++ b/src/Generators/Scss.vitest.snap
@@ -23,11 +23,13 @@ $token-values: (
 
 /// Use "get-token" to access tokens by name
 @function get-token($name) {
-  @if (not map.has-key($token-values, $name)) {
+  @if not map.has-key($token-values, $name) {
     @error "Token '#{$name}' does not exist.";
   }
+
   @return map.get($token-values, $name);
-}"
+}
+"
 `;
 
 exports[`Scss Generator tests > composite values with internal commas produce valid SCSS map output 1`] = `
@@ -48,11 +50,13 @@ $token-values: (
 
 /// Use "get-token" to access tokens by name
 @function get-token($name) {
-  @if (not map.has-key($token-values, $name)) {
+  @if not map.has-key($token-values, $name) {
     @error "Token '#{$name}' does not exist.";
   }
+
   @return map.get($token-values, $name);
-}"
+}
+"
 `;
 
 exports[`Scss Generator tests > it generates group maps and functions when groups: true 1`] = `
@@ -75,9 +79,10 @@ $token-values: (
 
 /// Use "get-token" to access tokens by name
 @function get-token($name) {
-  @if (not map.has-key($token-values, $name)) {
+  @if not map.has-key($token-values, $name) {
     @error "Token '#{$name}' does not exist.";
   }
+
   @return map.get($token-values, $name);
 }
 
@@ -90,6 +95,7 @@ $color-values: (
   @if not map.has-key($color-values, $name) {
     @error "Unknown color token '#{$name}'. Available: #{map.keys($color-values)}";
   }
+
   @return map.get($color-values, $name);
 }
 
@@ -101,8 +107,10 @@ $spacing-values: (
   @if not map.has-key($spacing-values, $name) {
     @error "Unknown spacing token '#{$name}'. Available: #{map.keys($spacing-values)}";
   }
+
   @return map.get($spacing-values, $name);
-}"
+}
+"
 `;
 
 exports[`Scss Generator tests > it generates groups with PrefixTypePlugin 1`] = `
@@ -128,9 +136,10 @@ $token-values: (
 
 /// Use "get-token" to access tokens by name
 @function get-token($name) {
-  @if (not map.has-key($token-values, $name)) {
+  @if not map.has-key($token-values, $name) {
     @error "Token '#{$name}' does not exist.";
   }
+
   @return map.get($token-values, $name);
 }
 
@@ -142,6 +151,7 @@ $font-family-values: (
   @if not map.has-key($font-family-values, $name) {
     @error "Unknown font-family token '#{$name}'. Available: #{map.keys($font-family-values)}";
   }
+
   @return map.get($font-family-values, $name);
 }
 
@@ -154,6 +164,8 @@ $color-values: (
   @if not map.has-key($color-values, $name) {
     @error "Unknown color token '#{$name}'. Available: #{map.keys($color-values)}";
   }
+
   @return map.get($color-values, $name);
-}"
+}
+"
 `;

--- a/src/Generators/ScssVars.ts
+++ b/src/Generators/ScssVars.ts
@@ -158,6 +158,7 @@ export class ScssVars extends Scss {
           `  @if not map.has-key($${groupKebab}-values, $name) {`,
           `    @error "Unknown ${groupKebab} token '#{$name}'. Available: #{map.keys($${groupKebab}-values)}";`,
           `  }`,
+          ``,
           `  @return map.get($${groupKebab}-values, $name);`,
           `}`,
         ].join(EOL);

--- a/src/Generators/ScssVars.vitest.snap
+++ b/src/Generators/ScssVars.vitest.snap
@@ -14,7 +14,8 @@ $body: "Roboto Condensed", Arial, sans;
 /// the primary branding color
 $primary: aliceblue;
 /// the secondary branding color
-$secondary: rgb(102, 205, 170);"
+$secondary: rgb(102, 205, 170);
+"
 `;
 
 exports[`SCSS Vars Generator tests > it generates group maps and functions when groups: true 1`] = `
@@ -41,6 +42,7 @@ $color-values: (
   @if not map.has-key($color-values, $name) {
     @error "Unknown color token '#{$name}'. Available: #{map.keys($color-values)}";
   }
+
   @return map.get($color-values, $name);
 }
 
@@ -52,6 +54,8 @@ $spacing-values: (
   @if not map.has-key($spacing-values, $name) {
     @error "Unknown spacing token '#{$name}'. Available: #{map.keys($spacing-values)}";
   }
+
   @return map.get($spacing-values, $name);
-}"
+}
+"
 `;

--- a/src/Generators/Storybook.vitest.snap
+++ b/src/Generators/Storybook.vitest.snap
@@ -41,5 +41,6 @@ export const Color: Story = {
         </TokenGrid>
     </TokenStory>
   ),
-};"
+};
+"
 `;

--- a/src/Generators/TypeScript.vitest.snap
+++ b/src/Generators/TypeScript.vitest.snap
@@ -38,6 +38,7 @@ export declare const color: (name: 'primary' | 'accent') => string;
 export declare const spacing: (name: 'sm') => string;
 export default tokens;
 
+
 === tokens.mjs ===
 /**
  * Teikn vtest
@@ -76,5 +77,6 @@ export const spacing = (name) => {
   return _spacing[name];
 };
 
-export default tokens;"
+export default tokens;
+"
 `;

--- a/src/Generators/TypeScriptDeclarations.vitest.snap
+++ b/src/Generators/TypeScriptDeclarations.vitest.snap
@@ -35,7 +35,8 @@ export type TokenNames = {
   Color: 'primary' | 'secondary';
   All: TokenNames['FontFamily'] | TokenNames['Color'];
 };
-export default tokens;"
+export default tokens;
+"
 `;
 
 exports[`TypeScriptDeclarations generator > it generates group type declarations when groups: true 1`] = `
@@ -73,5 +74,6 @@ export type TokenNames = {
 
 export declare const color: (name: 'primary' | 'secondary') => string;
 export declare const spacing: (name: 'sm') => string;
-export default tokens;"
+export default tokens;
+"
 `;

--- a/src/Generators/__snapshots__/CssVars.test.ts.snap
+++ b/src/Generators/__snapshots__/CssVars.test.ts.snap
@@ -14,7 +14,8 @@ exports[`CssVars Generator tests It generates the token set 1`] = `
   --primary: aliceblue;
   /* the secondary branding color */
   --secondary: rgb(102, 205, 170);
-}"
+}
+"
 `;
 
 exports[`CssVars Generator tests It generates themed tokens with modes 1`] = `
@@ -32,7 +33,8 @@ exports[`CssVars Generator tests It generates themed tokens with modes 1`] = `
 [data-theme="dark"] {
   --bg: #1a1a1a;
   --text: #eeeeee;
-}"
+}
+"
 `;
 
 exports[`CssVars Generator tests modeSelectors wraps at-rule strings in :root 1`] = `
@@ -50,7 +52,8 @@ exports[`CssVars Generator tests modeSelectors wraps at-rule strings in :root 1`
   :root {
     --bg: #1a1a1a;
   }
-}"
+}
+"
 `;
 
 exports[`CssVars Generator tests modeSelectors object form uses custom selector inside at-rule 1`] = `
@@ -68,7 +71,8 @@ exports[`CssVars Generator tests modeSelectors object form uses custom selector 
   .app {
     --bg: #1a1a1a;
   }
-}"
+}
+"
 `;
 
 exports[`CssVars Generator tests modeSelectors handles mix of selectors and at-rules 1`] = `
@@ -90,5 +94,6 @@ exports[`CssVars Generator tests modeSelectors handles mix of selectors and at-r
 
 .high-contrast {
   --bg: #000000;
-}"
+}
+"
 `;

--- a/src/Generators/__snapshots__/Dtcg.test.ts.snap
+++ b/src/Generators/__snapshots__/Dtcg.test.ts.snap
@@ -64,5 +64,6 @@ exports[`DtcgGenerator tests snapshot test with standard token set 1`] = `
     },
     "$type": "number"
   }
-}"
+}
+"
 `;

--- a/src/Generators/__snapshots__/Html.test.ts.snap
+++ b/src/Generators/__snapshots__/Html.test.ts.snap
@@ -348,5 +348,6 @@ section h2{font-size:1.25rem;font-weight:600;margin-bottom:1rem;padding-bottom:0
   }
 });</script>
 </body>
-</html>"
+</html>
+"
 `;

--- a/src/Generators/__snapshots__/JavaScript.test.ts.snap
+++ b/src/Generators/__snapshots__/JavaScript.test.ts.snap
@@ -25,7 +25,8 @@ export const tokens = {
   secondary: 'rgb(102, 205, 170)',
 };
 
-export default tokens;"
+export default tokens;
+"
 `;
 
 exports[`JavaScript generator (ESM default) it generates group accessors when groups: true 1`] = `
@@ -66,5 +67,6 @@ export const spacing = (name) => {
   return _spacing[name];
 };
 
-export default tokens;"
+export default tokens;
+"
 `;

--- a/src/Generators/__snapshots__/Json.test.ts.snap
+++ b/src/Generators/__snapshots__/Json.test.ts.snap
@@ -17,5 +17,6 @@ exports[`JSONGenerator tests It generates the token set 1`] = `
     "usage": "the secondary branding color",
     "value": "rgb(102, 205, 170)"
   }
-}"
+}
+"
 `;

--- a/src/Generators/__snapshots__/Scss.test.ts.snap
+++ b/src/Generators/__snapshots__/Scss.test.ts.snap
@@ -23,11 +23,13 @@ $token-values: (
 
 /// Use "get-token" to access tokens by name
 @function get-token($name) {
-  @if (not map.has-key($token-values, $name)) {
+  @if not map.has-key($token-values, $name) {
     @error "Token '#{$name}' does not exist.";
   }
+
   @return map.get($token-values, $name);
-}"
+}
+"
 `;
 
 exports[`Scss Generator tests it generates group maps and functions when groups: true 1`] = `
@@ -50,9 +52,10 @@ $token-values: (
 
 /// Use "get-token" to access tokens by name
 @function get-token($name) {
-  @if (not map.has-key($token-values, $name)) {
+  @if not map.has-key($token-values, $name) {
     @error "Token '#{$name}' does not exist.";
   }
+
   @return map.get($token-values, $name);
 }
 
@@ -65,6 +68,7 @@ $color-values: (
   @if not map.has-key($color-values, $name) {
     @error "Unknown color token '#{$name}'. Available: #{map.keys($color-values)}";
   }
+
   @return map.get($color-values, $name);
 }
 
@@ -76,8 +80,10 @@ $spacing-values: (
   @if not map.has-key($spacing-values, $name) {
     @error "Unknown spacing token '#{$name}'. Available: #{map.keys($spacing-values)}";
   }
+
   @return map.get($spacing-values, $name);
-}"
+}
+"
 `;
 
 exports[`Scss Generator tests it generates groups with PrefixTypePlugin 1`] = `
@@ -103,9 +109,10 @@ $token-values: (
 
 /// Use "get-token" to access tokens by name
 @function get-token($name) {
-  @if (not map.has-key($token-values, $name)) {
+  @if not map.has-key($token-values, $name) {
     @error "Token '#{$name}' does not exist.";
   }
+
   @return map.get($token-values, $name);
 }
 
@@ -117,6 +124,7 @@ $font-family-values: (
   @if not map.has-key($font-family-values, $name) {
     @error "Unknown font-family token '#{$name}'. Available: #{map.keys($font-family-values)}";
   }
+
   @return map.get($font-family-values, $name);
 }
 
@@ -129,8 +137,10 @@ $color-values: (
   @if not map.has-key($color-values, $name) {
     @error "Unknown color token '#{$name}'. Available: #{map.keys($color-values)}";
   }
+
   @return map.get($color-values, $name);
-}"
+}
+"
 `;
 
 exports[`Scss Generator tests composite values with internal commas produce valid SCSS map output 1`] = `
@@ -151,9 +161,11 @@ $token-values: (
 
 /// Use "get-token" to access tokens by name
 @function get-token($name) {
-  @if (not map.has-key($token-values, $name)) {
+  @if not map.has-key($token-values, $name) {
     @error "Token '#{$name}' does not exist.";
   }
+
   @return map.get($token-values, $name);
-}"
+}
+"
 `;

--- a/src/Generators/__snapshots__/ScssVars.test.ts.snap
+++ b/src/Generators/__snapshots__/ScssVars.test.ts.snap
@@ -14,7 +14,8 @@ $body: "Roboto Condensed", Arial, sans;
 /// the primary branding color
 $primary: aliceblue;
 /// the secondary branding color
-$secondary: rgb(102, 205, 170);"
+$secondary: rgb(102, 205, 170);
+"
 `;
 
 exports[`SCSS Vars Generator tests it generates group maps and functions when groups: true 1`] = `
@@ -41,6 +42,7 @@ $color-values: (
   @if not map.has-key($color-values, $name) {
     @error "Unknown color token '#{$name}'. Available: #{map.keys($color-values)}";
   }
+
   @return map.get($color-values, $name);
 }
 
@@ -52,6 +54,8 @@ $spacing-values: (
   @if not map.has-key($spacing-values, $name) {
     @error "Unknown spacing token '#{$name}'. Available: #{map.keys($spacing-values)}";
   }
+
   @return map.get($spacing-values, $name);
-}"
+}
+"
 `;

--- a/src/Generators/__snapshots__/Storybook.test.ts.snap
+++ b/src/Generators/__snapshots__/Storybook.test.ts.snap
@@ -41,5 +41,6 @@ export const Color: Story = {
         </TokenGrid>
     </TokenStory>
   ),
-};"
+};
+"
 `;

--- a/src/Generators/__snapshots__/TypeScript.test.ts.snap
+++ b/src/Generators/__snapshots__/TypeScript.test.ts.snap
@@ -38,6 +38,7 @@ export declare const color: (name: 'primary' | 'accent') => string;
 export declare const spacing: (name: 'sm') => string;
 export default tokens;
 
+
 === tokens.mjs ===
 /**
  * Teikn vtest
@@ -76,5 +77,6 @@ export const spacing = (name) => {
   return _spacing[name];
 };
 
-export default tokens;"
+export default tokens;
+"
 `;

--- a/src/Generators/__snapshots__/TypeScriptDeclarations.test.ts.snap
+++ b/src/Generators/__snapshots__/TypeScriptDeclarations.test.ts.snap
@@ -35,7 +35,8 @@ export type TokenNames = {
   Color: 'primary' | 'secondary';
   All: TokenNames['FontFamily'] | TokenNames['Color'];
 };
-export default tokens;"
+export default tokens;
+"
 `;
 
 exports[`TypeScriptDeclarations generator it generates group type declarations when groups: true 1`] = `
@@ -73,5 +74,6 @@ export type TokenNames = {
 
 export declare const color: (name: 'primary' | 'secondary') => string;
 export declare const spacing: (name: 'sm') => string;
-export default tokens;"
+export default tokens;
+"
 `;

--- a/src/Generators/value-serializers.ts
+++ b/src/Generators/value-serializers.ts
@@ -6,7 +6,21 @@ import { isFirstClassValue } from "../type-classifiers.js";
 // ─── CSS/SCSS value serialization ────────────────────────────────
 // Shared by CssVars, Scss, and ScssVars generators.
 
+const MAX_PRECISION = 4;
+
+const roundNumber = (n: number): string => {
+  const str = String(n);
+  const dot = str.indexOf(".");
+  if (dot === -1 || str.length - dot - 1 <= MAX_PRECISION) {
+    return str;
+  }
+  return parseFloat(n.toFixed(MAX_PRECISION)).toString();
+};
+
 export const cssValue = (value: unknown): string => {
+  if (typeof value === "number") {
+    return roundNumber(value);
+  }
   if (typeof value !== "object" || value === null) {
     return String(value);
   }


### PR DESCRIPTION
- Add blank line before `@return` in SCSS function blocks (readability)
- Drop parens from `@if` conditions to match Stylelint expectations
- Round numbers to max 4 decimal places (`number-max-precision`)
- End all generated files with a final newline (POSIX `eol-last`)
