### PR TITLE
Fix alpha precision and silence runAfter warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+## 2.0.0-beta.2
+
+### Fixed
+
+- **Color alpha precision.** Alpha channel now rounds to 4 decimal places
+  in all color format serializers (rgba, hsla, lab, lch).
+- **Noisy `runAfter` warnings removed.** Missing targets are silently
+  skipped — they're ordering hints, not requirements.
+
+## 2.0.0-beta.1
+
+### Fixed
+
+- **Generated SCSS passes Stylelint.** Blank line before `@return`, dropped
+  `@if` parens, number precision capped at 4, final newline on all files.
+- **Dropped wall-clock date from generated headers.** No more spurious diffs
+  on every CI run. `dateFn` still available as an opt-in.
+
+## 2.0.0-beta.0
+
+### Changed
+
+- **`filenames()` is a hard contract.** Generators that emit or omit files
+  not matching their declaration now throw.
+- **Dot forbidden in token name/group.** Duplicate qualified keys are errors.
+- **Reject `{ref}` strings inside first-class value wrappers.**
+- **Plugin errors include plugin name + token name.**
+- **`sortPlugins` warns on unknown `runAfter` targets.**
+
+### Fixed
+
+- **`Scss` honors its `prefix` option** (was typed but unread).
+- **`.d.cts` declarations emitted for `module: "cjs"`.**
+- **Path separators rejected in `filename`** — was silently writing outside outDir.
+
+### Added
+
+- **`DeprecationPlugin`** shows `@deprecated` JSDoc in JS/TS output.
+- ~170 new tests including a seeded fuzzer over the token graph.
+
 ## 2.0.0-alpha.14
 
 ### Added

--- a/src/Plugins/Plugin.ts
+++ b/src/Plugins/Plugin.ts
@@ -67,11 +67,6 @@ export const sortPlugins = (plugins: Plugin[]): Plugin[] => {
       const depPlugin = nameMap.get(dep);
       if (depPlugin) {
         visit(depPlugin);
-      } else {
-        console.error(
-          `Plugin \`${name}\` declares \`runAfter: ["${dep}"]\`, but no plugin named \`${dep}\` is registered. ` +
-            `The ordering hint is being ignored. Check for a typo or remove the entry.`,
-        );
       }
     }
     visiting.delete(name);

--- a/src/Plugins/plugin-stress.test.ts
+++ b/src/Plugins/plugin-stress.test.ts
@@ -73,27 +73,15 @@ describe("Scenario 1 — cycle in runAfter", () => {
 // ─── Scenario 2: unregistered runAfter target ────────────────
 
 describe("Scenario 2 — runAfter references unregistered plugin", () => {
-  test("missing runAfter targets log to stderr and continue", () => {
+  test("missing runAfter targets are silently skipped", () => {
     class Dependent extends Plugin {
       tokenType: RegExp = /.*/;
       outputType: RegExp = /.*/;
       override readonly runAfter: string[] = ["NotARealPlugin"];
     }
     const d = new Dependent();
-    const original = console.error;
-    const messages: string[] = [];
-    console.error = (msg: string) => {
-      messages.push(msg);
-    };
-    try {
-      const result = sortPlugins([d]);
-      expect(result).toEqual([d]);
-    } finally {
-      console.error = original;
-    }
-    expect(messages.length).toBe(1);
-    expect(messages[0]).toMatch(/Dependent/);
-    expect(messages[0]).toMatch(/NotARealPlugin/);
+    const result = sortPlugins([d]);
+    expect(result).toEqual([d]);
   });
 });
 

--- a/src/TokenTypes/Color/Color.ts
+++ b/src/TokenTypes/Color/Color.ts
@@ -32,6 +32,11 @@ const INTERNAL: unique symbol = Symbol("Color.internal");
 
 export type InternalCreate = (space: Space, data: SpaceData[Space], alpha: number) => Color;
 
+// CSS Color 4 serialization precision per color space
+const PRECISION_ALPHA = 4;
+const PRECISION_LAB = 2;
+const PRECISION_XYZ = 5;
+
 // String formatters — each handles both opaque and alpha variants
 const fmtTriplet = (
   name: string,
@@ -42,37 +47,37 @@ const fmtTriplet = (
   alpha?: number,
 ): string => {
   const core = `${round(precision, a)}, ${round(precision, b)}, ${round(precision, c)}`;
-  return alpha !== undefined ? `${name}(${core} / ${alpha})` : `${name}(${core})`;
+  return alpha !== undefined ? `${name}(${core} / ${round(PRECISION_ALPHA, alpha)})` : `${name}(${core})`;
 };
 
 const fmt = {
   rgb: (values: RGB | RGBA): string => {
     const [r, g, b] = values;
     const core = `${r}, ${g}, ${b}`;
-    return values.length === 4 ? `rgba(${core}, ${values[3]})` : `rgb(${core})`;
+    return values.length === 4 ? `rgba(${core}, ${round(PRECISION_ALPHA, values[3])})` : `rgb(${core})`;
   },
   hsl: (values: HSL | HSLA): string => {
     const [h, s, l] = values;
     const core = `${h}, ${toPercent(s)}, ${toPercent(l)}`;
-    return values.length === 4 ? `hsla(${core}, ${values[3]})` : `hsl(${core})`;
+    return values.length === 4 ? `hsla(${core}, ${round(PRECISION_ALPHA, values[3])})` : `hsl(${core})`;
   },
   lab: (values: LAB | LABA): string => {
     const [L, a, b] = values;
     return values.length === 4
-      ? fmtTriplet("lab", 2, L, a, b, values[3])
-      : fmtTriplet("lab", 2, L, a, b);
+      ? fmtTriplet("lab", PRECISION_LAB, L, a, b, values[3])
+      : fmtTriplet("lab", PRECISION_LAB, L, a, b);
   },
   lch: (values: LCH | LCHA): string => {
     const [L, c, h] = values;
     return values.length === 4
-      ? fmtTriplet("lch", 2, L, c, h, values[3])
-      : fmtTriplet("lch", 2, L, c, h);
+      ? fmtTriplet("lch", PRECISION_LAB, L, c, h, values[3])
+      : fmtTriplet("lch", PRECISION_LAB, L, c, h);
   },
   xyz: (values: XYZ | XYZA): string => {
     const [x, y, z] = values;
     return values.length === 4
-      ? fmtTriplet("xyz", 5, x, y, z, values[3])
-      : fmtTriplet("xyz", 5, x, y, z);
+      ? fmtTriplet("xyz", PRECISION_XYZ, x, y, z, values[3])
+      : fmtTriplet("xyz", PRECISION_XYZ, x, y, z);
   },
 };
 

--- a/src/TokenTypes/Color/Color.ts
+++ b/src/TokenTypes/Color/Color.ts
@@ -47,19 +47,25 @@ const fmtTriplet = (
   alpha?: number,
 ): string => {
   const core = `${round(precision, a)}, ${round(precision, b)}, ${round(precision, c)}`;
-  return alpha !== undefined ? `${name}(${core} / ${round(PRECISION_ALPHA, alpha)})` : `${name}(${core})`;
+  return alpha !== undefined
+    ? `${name}(${core} / ${round(PRECISION_ALPHA, alpha)})`
+    : `${name}(${core})`;
 };
 
 const fmt = {
   rgb: (values: RGB | RGBA): string => {
     const [r, g, b] = values;
     const core = `${r}, ${g}, ${b}`;
-    return values.length === 4 ? `rgba(${core}, ${round(PRECISION_ALPHA, values[3])})` : `rgb(${core})`;
+    return values.length === 4
+      ? `rgba(${core}, ${round(PRECISION_ALPHA, values[3])})`
+      : `rgb(${core})`;
   },
   hsl: (values: HSL | HSLA): string => {
     const [h, s, l] = values;
     const core = `${h}, ${toPercent(s)}, ${toPercent(l)}`;
-    return values.length === 4 ? `hsla(${core}, ${round(PRECISION_ALPHA, values[3])})` : `hsl(${core})`;
+    return values.length === 4
+      ? `hsla(${core}, ${round(PRECISION_ALPHA, values[3])})`
+      : `hsl(${core})`;
   },
   lab: (values: LAB | LABA): string => {
     const [L, a, b] = values;

--- a/src/TokenTypes/Color/color.test.ts
+++ b/src/TokenTypes/Color/color.test.ts
@@ -279,6 +279,13 @@ describe("Color tests", () => {
     expect(new Color(0, 0, 0, 0).setAlpha(0.5).toString()).toBe("rgba(0, 0, 0, 0.5)");
   });
 
+  test("alpha precision is capped at 4 decimal places", () => {
+    expect(new Color(0, 0, 0, 0.8631111111111112).toString("rgba")).toBe("rgba(0, 0, 0, 0.8631)");
+    expect(new Color(0, 0, 0, 0.123456789).toString("rgba")).toBe("rgba(0, 0, 0, 0.1235)");
+    expect(new Color(0, 0, 0, 0.54).toString("rgba")).toBe("rgba(0, 0, 0, 0.54)");
+    expect(new Color(0, 0, 0, 0.333333333).toString("hsla")).toBe("hsla(0, 0%, 0%, 0.3333)");
+  });
+
   // ─── HSL mutation tests ──────────────────────────────────
 
   test("Setting Hue works", () => {


### PR DESCRIPTION
## Summary
- Round alpha channel to 4 decimal places in all color serializers
- Silence `runAfter` warnings for missing (optional) plugin targets
- Add changelog entries for beta.0 through beta.2
