### PR TITLE
Fix Storybook dark mode + border/shadow rendering, and tidy up type classification

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,11 +1,21 @@
-import type { StorybookConfig } from '@storybook/react-vite';
+import type { StorybookConfig } from "@storybook/react-vite";
 
 const config: StorybookConfig = {
-  stories: ['../example/dist/**/*.stories.tsx'],
-  framework: '@storybook/react-vite',
+  stories: ["../example/dist/**/*.stories.tsx"],
+  framework: "@storybook/react-vite",
   typescript: {
     reactDocgen: false,
   },
+  // Force Vite to pre-bundle React so a synthetic `default` export exists.
+  // Without this, modules doing `import React from "react"` fail against
+  // React's raw CJS entry ("does not provide an export named 'default'").
+  viteFinal: async (cfg) => ({
+    ...cfg,
+    optimizeDeps: {
+      ...cfg.optimizeDeps,
+      include: [...(cfg.optimizeDeps?.include ?? []), "react", "react-dom", "react/jsx-runtime"],
+    },
+  }),
 };
 
 export default config;

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,9 +1,39 @@
-import type { Preview } from '@storybook/react';
+import type { Preview } from "@storybook/react";
 
 const preview: Preview = {
   parameters: {
-    layout: 'padded',
+    layout: "fullscreen",
   },
+  // Toolbar switcher so the token theme can be previewed without changing the
+  // OS setting. The teikn components read `[data-theme="dark"]`, so the
+  // decorator just sets that attribute on <html>; "auto" defers to the OS.
+  globalTypes: {
+    theme: {
+      description: "Token theme",
+      defaultValue: "light",
+      toolbar: {
+        title: "Theme",
+        icon: "mirror",
+        items: [
+          { value: "light", title: "Light" },
+          { value: "dark", title: "Dark" },
+          { value: "auto", title: "Auto (OS)" },
+        ],
+        dynamicTitle: true,
+      },
+    },
+  },
+  decorators: [
+    (Story, ctx) => {
+      const theme = ctx.globals.theme;
+      if (theme === "auto") {
+        document.documentElement.removeAttribute("data-theme");
+      } else {
+        document.documentElement.setAttribute("data-theme", theme);
+      }
+      return Story();
+    },
+  ],
 };
 
 export default preview;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## 2.0.0-beta.3
+
+### Added
+
+- **Documentation `preview` hint.** Pass `group({ type, preview }, …)` (also on
+  `scale`/`composite`) to override how a token is visualized in the `Storybook`
+  and `Html` generators — e.g. `{ type: "elevation", preview: "shadow" }`. It's
+  presentational only and never affects CSS/SCSS/JS/DTCG output; when omitted,
+  the kind is inferred from `type` as before.
+
+### Fixed
+
+- **Storybook dark mode.** The theme wrapper now paints its own
+  background/color, so cards no longer float on a white canvas. Added a
+  `darkMode` option to opt out of the dark chrome entirely.
+- **Shadow swatches in dark mode.** Box-shadows now render on a light stage so
+  the semi-transparent shadow stays visible.
+- **`border-width`, `border-style`, and bare `radius` tokens.** These rendered
+  as a plain table; they now get proper visual samples.
+- **`Html` crash with no `dateFn`.** `header()` no longer assumes the optional
+  `dateFn` is present.
+
+### Changed
+
+- **Single source of truth for token-type classification.** The per-generator
+  regex ladders are replaced by `classifyTokenType` + `resolvePreviewKind`;
+  behavior is unchanged for existing token sets.
+
 ## 2.0.0-beta.2
 
 ### Fixed

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@shawnrice/teikn",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0-beta.3",
   "exports": {
     ".": "./index.ts",
     "./builders": "./src/builders.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teikn",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0-beta.3",
   "description": "Generate design tokens",
   "keywords": [
     "design",

--- a/src/Generators/Html.ts
+++ b/src/Generators/Html.ts
@@ -1,34 +1,16 @@
 import { EOL } from "node:os";
 
 import { kebabCase } from "../string-utils.js";
-import type { CompositeValue, Token, TokenValue } from "../Token.js";
+import type { CompositeValue, PreviewKind, Token, TokenValue } from "../Token.js";
 import { Color } from "../TokenTypes/Color/index.js";
 import { CubicBezier } from "../TokenTypes/CubicBezier.js";
 import { GradientList, LinearGradient, RadialGradient } from "../TokenTypes/Gradient.js";
 import { Transition } from "../TokenTypes/Transition.js";
 import {
   groupTokens,
-  isAspectRatioType,
-  isBorderRadiusType,
-  isBorderType,
-  isBreakpointType,
   isColorType,
-  isDurationType,
   isFirstClassValue,
-  isFontFamilyType,
-  isFontSizeType,
-  isFontWeightType,
-  isGradientType,
-  isLetterSpacingType,
-  isLineHeightType,
-  isOpacityType,
-  isShadowType,
-  isSizeType,
-  isSpacingType,
-  isTimingType,
-  isTransitionType,
-  isTypographyType,
-  isZLayerType,
+  resolvePreviewKind,
 } from "../type-classifiers.js";
 import type { GeneratorOptions } from "./Generator.js";
 import { Generator } from "./Generator.js";
@@ -44,6 +26,20 @@ export type HtmlOpts = {
 } & GeneratorOptions;
 
 // ─── Helpers ─────────────────────────────────────────────────
+
+// CSS class for the grid wrapper around a section's visualizations, by kind.
+// Kinds not listed render in the default (non-grid) flow.
+const gridClassByKind: Partial<Record<PreviewKind, string>> = {
+  color: "color-grid",
+  shadow: "shadow-grid",
+  borderRadius: "radius-grid",
+  gradient: "gradient-grid",
+  opacity: "opacity-grid",
+  size: "size-grid",
+  aspectRatio: "ratio-grid",
+};
+
+const vizClassForKind = (kind: PreviewKind): string => gridClassByKind[kind] ?? "";
 
 const escapeHtml = (str: string): string =>
   str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
@@ -1046,104 +1042,76 @@ export class Html extends Generator<HtmlOpts> {
 
   // ── Routing ────────────────────────────────────────────────
 
-  private renderVisualization(token: Token): string {
-    const { type, value } = token;
+  // Generic composite fallback: render an object value as a composite,
+  // otherwise nothing. Used by kinds Html has no bespoke renderer for.
+  private renderCompositeFallback(token: Token): string {
+    return typeof token.value === "object" && !isFirstClassValue(token.value)
+      ? this.renderCompositeToken(token)
+      : "";
+  }
 
-    // Specific type renderers (check before generic composite)
-    if (isColorType(type)) {
-      return this.renderColorToken(token);
-    }
-    if (isTypographyType(type) && typeof value === "object" && !isFirstClassValue(value)) {
-      return this.renderTypographyToken(token);
-    }
-    if (isShadowType(type)) {
-      return this.renderShadowToken(token);
-    }
-    if (isDurationType(type)) {
-      return this.renderDurationToken(token);
-    }
-    if (isTimingType(type)) {
-      return this.renderTimingToken(token);
-    }
-    if (isBorderRadiusType(type)) {
-      return this.renderBorderRadiusToken(token);
-    }
-    if (isBorderType(type) && typeof value === "object" && !isFirstClassValue(value)) {
-      return this.renderBorderToken(token);
-    }
-    if (isFontSizeType(type)) {
-      return this.renderFontToken(token, "font-size");
-    }
-    if (isFontFamilyType(type)) {
-      return this.renderFontToken(token, "font-family");
-    }
-    if (isFontWeightType(type)) {
-      return this.renderFontToken(token, "font-weight");
-    }
-    if (isLetterSpacingType(type)) {
-      return this.renderLetterSpacingToken(token);
-    }
-    if (isSpacingType(type)) {
-      return this.renderSpacingToken(token);
-    }
+  private renderVisualization(token: Token): string {
+    const { value } = token;
+
+    // Gradient values can appear under any type, so match the value first.
     if (
-      isGradientType(type) ||
       value instanceof LinearGradient ||
       value instanceof RadialGradient ||
       value instanceof GradientList
     ) {
       return this.renderGradientToken(token);
     }
-    if (isOpacityType(type)) {
-      return this.renderOpacityToken(token);
-    }
-    if (isLineHeightType(type)) {
-      return this.renderLineHeightToken(token);
-    }
-    if (isBreakpointType(type)) {
-      return this.renderBreakpointToken(token);
-    }
-    if (isSizeType(type)) {
-      return this.renderSizeToken(token);
-    }
-    if (isAspectRatioType(type)) {
-      return this.renderAspectRatioToken(token);
-    }
-    if (isTransitionType(type)) {
-      return this.renderTransitionToken(token);
-    }
 
-    // Generic composite fallback
-    if (typeof value === "object" && !isFirstClassValue(value)) {
-      return this.renderCompositeToken(token);
+    switch (resolvePreviewKind(token)) {
+      case "color":
+        return this.renderColorToken(token);
+      // Typography/border only get a bespoke preview when the value is a
+      // composite object; scalars fall through to the generic fallback.
+      case "typography":
+        return typeof value === "object" && !isFirstClassValue(value)
+          ? this.renderTypographyToken(token)
+          : this.renderCompositeFallback(token);
+      case "border":
+        return typeof value === "object" && !isFirstClassValue(value)
+          ? this.renderBorderToken(token)
+          : this.renderCompositeFallback(token);
+      case "shadow":
+        return this.renderShadowToken(token);
+      case "duration":
+        return this.renderDurationToken(token);
+      case "timing":
+        return this.renderTimingToken(token);
+      case "borderRadius":
+        return this.renderBorderRadiusToken(token);
+      case "fontSize":
+        return this.renderFontToken(token, "font-size");
+      case "fontFamily":
+        return this.renderFontToken(token, "font-family");
+      case "fontWeight":
+        return this.renderFontToken(token, "font-weight");
+      case "letterSpacing":
+        return this.renderLetterSpacingToken(token);
+      case "spacing":
+        return this.renderSpacingToken(token);
+      case "gradient":
+        return this.renderGradientToken(token);
+      case "opacity":
+        return this.renderOpacityToken(token);
+      case "lineHeight":
+        return this.renderLineHeightToken(token);
+      case "breakpoint":
+        return this.renderBreakpointToken(token);
+      case "size":
+        return this.renderSizeToken(token);
+      case "aspectRatio":
+        return this.renderAspectRatioToken(token);
+      case "transition":
+        return this.renderTransitionToken(token);
+      // borderWidth/borderStyle (no bespoke Html renderer), zLayer (handled at
+      // the section level), and table all fall back to the generic renderer.
+      default:
+        return this.renderCompositeFallback(token);
     }
-
-    return "";
-  }
-
-  private vizClassForType(type: string): string {
-    if (isColorType(type)) {
-      return "color-grid";
-    }
-    if (isShadowType(type)) {
-      return "shadow-grid";
-    }
-    if (isBorderRadiusType(type)) {
-      return "radius-grid";
-    }
-    if (isGradientType(type)) {
-      return "gradient-grid";
-    }
-    if (isOpacityType(type)) {
-      return "opacity-grid";
-    }
-    if (isSizeType(type)) {
-      return "size-grid";
-    }
-    if (isAspectRatioType(type)) {
-      return "ratio-grid";
-    }
-    return "";
   }
 
   private wrapWithFlip(cardHtml: string, token: Token): string {
@@ -1197,10 +1165,13 @@ export class Html extends Generator<HtmlOpts> {
   private renderSection(type: string, tokens: Token[]): string {
     const id = slugify(type);
     const rows = tokens.map((t) => this.generateToken(t));
-    const vizClass = this.vizClassForType(type);
+    // All tokens in a section share a type (and preview), so the first is
+    // representative of how the whole section should be pictured.
+    const kind = resolvePreviewKind(tokens[0]!);
+    const isZLayer = kind === "zLayer";
 
     // Z-layer gets a special stacked visualization (no flip cards)
-    const vizs = isZLayerType(type)
+    const vizs = isZLayer
       ? tokens.map((t, i) => this.renderZLayerToken(t, i, tokens.length))
       : tokens
           .map((t) => {
@@ -1213,7 +1184,7 @@ export class Html extends Generator<HtmlOpts> {
           })
           .filter(Boolean);
 
-    const vizWrapClass = isZLayerType(type) ? "zlayer-stack" : vizClass;
+    const vizWrapClass = isZLayer ? "zlayer-stack" : vizClassForKind(kind);
 
     return [
       `<section id="section-${id}">`,
@@ -1301,6 +1272,8 @@ export class Html extends Generator<HtmlOpts> {
 
   override header(): string {
     const { dateFn } = this.options;
+    const date = dateFn ? dateFn() : null;
+    const generated = date ? ` · Generated ${escapeHtml(date)}` : "";
 
     return [
       `<!DOCTYPE html>`,
@@ -1314,7 +1287,7 @@ export class Html extends Generator<HtmlOpts> {
       `<body>`,
       `<header class="page-header">`,
       `<h1>Design Tokens</h1>`,
-      `<p class="meta">${escapeHtml(this.signature())} · Generated ${escapeHtml(String(dateFn!()))}</p>`,
+      `<p class="meta">${escapeHtml(this.signature())}${generated}</p>`,
       `</header>`,
       `<div class="layout">`,
     ].join(EOL);

--- a/src/Generators/Storybook.test.ts
+++ b/src/Generators/Storybook.test.ts
@@ -219,6 +219,87 @@ describe("Storybook generator", () => {
     expect(output).toContain("RadiusBox");
   });
 
+  test("A preview hint overrides type inference (elevation → ShadowBox)", () => {
+    const sb = new Storybook({ dateFn: fixedDate, version: "test", importPath: "./tokens" });
+    const tokens: Token[] = [
+      {
+        name: "elevationCard",
+        type: "elevation",
+        preview: "shadow",
+        value: new BoxShadow(0, 1, 2, 0, "rgba(0,0,0,.12)"),
+      },
+    ];
+    const output = sb.generate(tokens);
+
+    expect(output).toContain("export const Elevation: Story");
+    expect(output).toContain("ShadowBox");
+    // Without the hint, "elevation" would fall back to the generic table.
+    expect(output).not.toContain("TokenTable");
+  });
+
+  test("A preview hint wins over a conflicting type inference (radius would be RadiusBox, forced to SpacingBar)", () => {
+    const sb = new Storybook({ dateFn: fixedDate, version: "test", importPath: "./tokens" });
+    const tokens: Token[] = [
+      // `type: "radius"` infers to borderRadius/RadiusBox; the explicit hint
+      // must override that and pick the spacing component instead.
+      { name: "radiusSm", type: "radius", preview: "spacing", value: "4px" },
+    ];
+    const output = sb.generate(tokens);
+
+    expect(output).toContain("SpacingBar");
+    expect(output).not.toContain("RadiusBox");
+  });
+
+  test("It renders bare radius stories with RadiusBox", () => {
+    const sb = new Storybook({ dateFn: fixedDate, version: "test", importPath: "./tokens" });
+    const tokens: Token[] = [{ name: "radiusSm", type: "radius", value: "4px" }];
+    const output = sb.generate(tokens);
+
+    expect(output).toContain("export const Radius: Story");
+    expect(output).toContain("RadiusBox");
+  });
+
+  test("It renders border-width stories with BorderWidthDemo", () => {
+    const sb = new Storybook({ dateFn: fixedDate, version: "test", importPath: "./tokens" });
+    const tokens: Token[] = [{ name: "borderWidthThin", type: "border-width", value: "1px" }];
+    const output = sb.generate(tokens);
+
+    expect(output).toContain("export const BorderWidth: Story");
+    expect(output).toContain("BorderWidthDemo");
+  });
+
+  test("It renders border-style stories with BorderStyleDemo", () => {
+    const sb = new Storybook({ dateFn: fixedDate, version: "test", importPath: "./tokens" });
+    const tokens: Token[] = [{ name: "borderStyleDashed", type: "border-style", value: "dashed" }];
+    const output = sb.generate(tokens);
+
+    expect(output).toContain("export const BorderStyle: Story");
+    expect(output).toContain("BorderStyleDemo");
+  });
+
+  test("It omits the dark chrome and forces light when darkMode is false", () => {
+    const sb = new Storybook({
+      dateFn: fixedDate,
+      version: "test",
+      importPath: "./tokens",
+      darkMode: false,
+    });
+    const tokens: Token[] = [{ name: "colorPrimary", type: "color", value: "#0066cc" }];
+    const output = sb.generate(tokens);
+
+    expect(output).toContain('<TokenStory colorScheme="light">');
+    expect(output).not.toContain("<TokenStory>");
+  });
+
+  test("It emits the dark chrome by default", () => {
+    const sb = new Storybook({ dateFn: fixedDate, version: "test", importPath: "./tokens" });
+    const tokens: Token[] = [{ name: "colorPrimary", type: "color", value: "#0066cc" }];
+    const output = sb.generate(tokens);
+
+    expect(output).toContain("<TokenStory>");
+    expect(output).not.toContain("colorScheme");
+  });
+
   test("It renders border stories with BorderDemo", () => {
     const sb = new Storybook({ dateFn: fixedDate, version: "test", importPath: "./tokens" });
     const tokens: Token[] = [
@@ -340,7 +421,7 @@ describe("Storybook generator", () => {
     expect(output).toContain("export default meta");
     expect(output).toContain("type Story = StoryObj<typeof meta>");
     expect(output).toContain("tags: ['autodocs']");
-    expect(output).toContain("layout: 'padded'");
+    expect(output).toContain("layout: 'fullscreen'");
     expect(output).not.toContain("import React");
     expect(output).toContain("<TokenStory>");
   });

--- a/src/Generators/Storybook.ts
+++ b/src/Generators/Storybook.ts
@@ -1,30 +1,8 @@
 import { EOL } from "node:os";
 
 import { camelCase } from "../string-utils.js";
-import type { Token } from "../Token.js";
-import {
-  groupTokens,
-  isAspectRatioType,
-  isBorderRadiusType,
-  isBorderType,
-  isBreakpointType,
-  isColorType,
-  isDurationType,
-  isFontFamilyType,
-  isFontSizeType,
-  isFontWeightType,
-  isGradientType,
-  isLetterSpacingType,
-  isLineHeightType,
-  isOpacityType,
-  isShadowType,
-  isSizeType,
-  isSpacingType,
-  isTimingType,
-  isTransitionType,
-  isTypographyType,
-  isZLayerType,
-} from "../type-classifiers.js";
+import type { PreviewKind, Token } from "../Token.js";
+import { groupTokens, resolvePreviewKind } from "../type-classifiers.js";
 import type { GeneratorInfo, GeneratorOptions } from "./Generator.js";
 import { Generator } from "./Generator.js";
 import { JavaScript } from "./JavaScript.js";
@@ -36,6 +14,7 @@ const defaultOptions = {
   ext: "stories.tsx",
   nameTransformer: camelCase,
   storyTitle: "Design Tokens",
+  darkMode: true,
 };
 
 export type StorybookOpts = {
@@ -43,6 +22,12 @@ export type StorybookOpts = {
   importPath?: string;
   storyTitle?: string;
   dateFn?: () => string | null;
+  /**
+   * Emit the dark-mode "chrome" (the `prefers-color-scheme` / `[data-theme]`
+   * variants). When `false`, stories render with the light palette only.
+   * Defaults to `true`.
+   */
+  darkMode?: boolean;
 } & GeneratorOptions;
 
 // ─── Type → component mapping ───────────────────────────────
@@ -54,69 +39,40 @@ type ComponentMapping = {
   valueType?: "composite" | "string";
 };
 
-const classifyType = (type: string): ComponentMapping => {
-  if (isColorType(type)) {
-    return { component: "Swatch", layout: "grid" };
-  }
-  if (isTypographyType(type)) {
-    return { component: "TypographyBlock", layout: "list", valueType: "composite" };
-  }
-  if (isFontSizeType(type)) {
-    return { component: "FontSample", layout: "list", extraProps: ' styleProp="fontSize"' };
-  }
-  if (isFontFamilyType(type)) {
-    return { component: "FontSample", layout: "list", extraProps: ' styleProp="fontFamily"' };
-  }
-  if (isFontWeightType(type)) {
-    return { component: "FontSample", layout: "list", extraProps: ' styleProp="fontWeight"' };
-  }
-  if (isShadowType(type)) {
-    return { component: "ShadowBox", layout: "grid" };
-  }
-  if (isDurationType(type)) {
-    return { component: "DurationBar", layout: "list" };
-  }
-  if (isTimingType(type)) {
-    return { component: "TimingDemo", layout: "list" };
-  }
-  if (isBorderRadiusType(type)) {
-    return { component: "RadiusBox", layout: "grid" };
-  }
-  if (isBorderType(type)) {
-    return { component: "BorderDemo", layout: "list", valueType: "composite" };
-  }
-  if (isLetterSpacingType(type)) {
-    return { component: "LetterSpacingSample", layout: "list" };
-  }
-  if (isSpacingType(type)) {
-    return { component: "SpacingBar", layout: "list" };
-  }
-  if (isGradientType(type)) {
-    return { component: "GradientSwatch", layout: "grid" };
-  }
-  if (isOpacityType(type)) {
-    return { component: "OpacityDemo", layout: "grid" };
-  }
-  if (isLineHeightType(type)) {
-    return { component: "LineHeightSample", layout: "list" };
-  }
-  if (isBreakpointType(type)) {
-    return { component: "BreakpointBar", layout: "list" };
-  }
-  if (isSizeType(type)) {
-    return { component: "SizeBox", layout: "grid" };
-  }
-  if (isAspectRatioType(type)) {
-    return { component: "RatioBox", layout: "grid" };
-  }
-  if (isZLayerType(type)) {
-    return { component: "ZLayerStack", layout: "none" };
-  }
-  if (isTransitionType(type)) {
-    return { component: "TransitionDemo", layout: "list" };
-  }
-  return { component: "TokenTable", layout: "none" };
+// Each preview kind maps to exactly one component + layout. Using a
+// Record (rather than an if-ladder) makes the mapping order-independent and
+// gives compile-time exhaustiveness: add a PreviewKind and TypeScript flags
+// the missing entry here.
+const componentByKind: Record<PreviewKind, ComponentMapping> = {
+  color: { component: "Swatch", layout: "grid" },
+  typography: { component: "TypographyBlock", layout: "list", valueType: "composite" },
+  fontSize: { component: "FontSample", layout: "list", extraProps: ' styleProp="fontSize"' },
+  fontFamily: { component: "FontSample", layout: "list", extraProps: ' styleProp="fontFamily"' },
+  fontWeight: { component: "FontSample", layout: "list", extraProps: ' styleProp="fontWeight"' },
+  shadow: { component: "ShadowBox", layout: "grid" },
+  duration: { component: "DurationBar", layout: "list" },
+  timing: { component: "TimingDemo", layout: "list" },
+  borderWidth: { component: "BorderWidthDemo", layout: "list" },
+  borderStyle: { component: "BorderStyleDemo", layout: "list" },
+  borderRadius: { component: "RadiusBox", layout: "grid" },
+  border: { component: "BorderDemo", layout: "list", valueType: "composite" },
+  letterSpacing: { component: "LetterSpacingSample", layout: "list" },
+  spacing: { component: "SpacingBar", layout: "list" },
+  gradient: { component: "GradientSwatch", layout: "grid" },
+  opacity: { component: "OpacityDemo", layout: "grid" },
+  lineHeight: { component: "LineHeightSample", layout: "list" },
+  breakpoint: { component: "BreakpointBar", layout: "list" },
+  size: { component: "SizeBox", layout: "grid" },
+  aspectRatio: { component: "RatioBox", layout: "grid" },
+  zLayer: { component: "ZLayerStack", layout: "none" },
+  transition: { component: "TransitionDemo", layout: "list" },
+  table: { component: "TokenTable", layout: "none" },
 };
+
+// All tokens in a group share a type (and, if set, a preview), so the first
+// token is representative of the whole group's visualization.
+const classifyGroup = (members: Token[]): ComponentMapping =>
+  componentByKind[resolvePreviewKind(members[0]!)];
 
 const toStoryName = (type: string): string => camelCase(type).replace(/^./, (c) => c.toUpperCase());
 
@@ -237,16 +193,15 @@ export class Storybook extends Generator<StorybookOpts> {
   }
 
   combinator(tokens: Token[]): string {
-    const { nameTransformer, storyTitle } = this.options;
+    const { nameTransformer, storyTitle, darkMode } = this.options;
     const ts = this.isTypeScript();
     const groups = groupTokens(tokens);
-    const types = [...groups.keys()];
     const hasModes = tokens.some((t) => t.modes && Object.keys(t.modes).length > 0);
 
     // Collect needed component imports
     const componentImports = new Set<string>(["TokenStory"]);
-    for (const type of types) {
-      const mapping = classifyType(type);
+    for (const typeTokens of groups.values()) {
+      const mapping = classifyGroup(typeTokens);
       componentImports.add(mapping.component);
       if (mapping.layout === "grid") {
         componentImports.add("TokenGrid");
@@ -304,7 +259,7 @@ export class Storybook extends Generator<StorybookOpts> {
     lines.push(`const meta = {`);
     lines.push(`  title: ${JSON.stringify(storyTitle)},`);
     lines.push(`  tags: ['autodocs'],`);
-    lines.push(`  parameters: { layout: 'padded' },`);
+    lines.push(`  parameters: { layout: 'fullscreen' },`);
     lines.push(`}${ts ? " satisfies Meta" : ""};`);
     lines.push(`export default meta;`);
     if (ts) {
@@ -317,13 +272,13 @@ export class Storybook extends Generator<StorybookOpts> {
     for (const [type, typeTokens] of groups) {
       const storyName = toStoryName(type);
       const keysVarName = `${camelCase(type)}Keys`;
-      const mapping = classifyType(type);
+      const mapping = classifyGroup(typeTokens);
       const typeModes =
         hasModes && typeTokens.some((t) => t.modes && Object.keys(t.modes).length > 0);
 
       lines.push(`export const ${storyName}${storyType} = {`);
       lines.push(`  render: () => (`);
-      lines.push(`    <TokenStory>`);
+      lines.push(`    ${darkMode ? `<TokenStory>` : `<TokenStory colorScheme="light">`}`);
       lines.push(...buildRenderBody(mapping, keysVarName, ts));
       if (typeModes) {
         lines.push(`        <ModeTable tokenKeys={${keysVarName}} modesData={modesData} />`);

--- a/src/Generators/Storybook.vitest.snap
+++ b/src/Generators/Storybook.vitest.snap
@@ -18,7 +18,7 @@ const colorKeys = ['primary', 'secondary'] as const;
 const meta = {
   title: "Design Tokens",
   tags: ['autodocs'],
-  parameters: { layout: 'padded' },
+  parameters: { layout: 'fullscreen' },
 } satisfies Meta;
 export default meta;
 type Story = StoryObj<typeof meta>;

--- a/src/Generators/__snapshots__/Storybook.test.ts.snap
+++ b/src/Generators/__snapshots__/Storybook.test.ts.snap
@@ -18,7 +18,7 @@ const colorKeys = ['primary', 'secondary'] as const;
 const meta = {
   title: "Design Tokens",
   tags: ['autodocs'],
-  parameters: { layout: 'padded' },
+  parameters: { layout: 'fullscreen' },
 } satisfies Meta;
 export default meta;
 type Story = StoryObj<typeof meta>;

--- a/src/Token.ts
+++ b/src/Token.ts
@@ -25,6 +25,45 @@ export type CompositeValue = Record<string, TokenValue>;
 
 export type ModeValues = Record<string, TokenValue | CompositeValue>;
 
+/**
+ * How a token should be *pictured* in the documentation generators
+ * (`Storybook`, `Html`). This is purely presentational — it never affects
+ * CSS/SCSS/JS/DTCG output. When a token doesn't carry one explicitly, the
+ * doc generators infer it from `type` (see `classifyTokenType`).
+ */
+export type PreviewKind =
+  | "color"
+  | "typography"
+  | "fontSize"
+  | "fontFamily"
+  | "fontWeight"
+  | "letterSpacing"
+  | "lineHeight"
+  | "borderWidth"
+  | "borderStyle"
+  | "borderRadius"
+  | "border"
+  | "shadow"
+  | "duration"
+  | "timing"
+  | "spacing"
+  | "gradient"
+  | "opacity"
+  | "breakpoint"
+  | "size"
+  | "aspectRatio"
+  | "zLayer"
+  | "transition"
+  | "table";
+
+/**
+ * The first argument to the group builders (`group`, `scale`, `composite`).
+ * A bare string is the common case; the object form lets an author attach a
+ * documentation-only `preview` hint at declaration time without changing the
+ * builder's arity.
+ */
+export type TypeSpec = { type: string; preview?: PreviewKind };
+
 export type Token = {
   name: string;
   value: TokenValue | CompositeValue;
@@ -32,6 +71,12 @@ export type Token = {
   type: string;
   group?: string;
   modes?: ModeValues;
+  /**
+   * Documentation-only visualization hint. Set via the object form of a
+   * builder's first argument (`group({ type, preview }, …)`). When absent,
+   * doc generators infer the kind from `type`.
+   */
+  preview?: PreviewKind;
   /**
    * Set by `DeprecationPlugin`. When `true`, the token is deprecated.
    * When a string, generators may surface it as a deprecation reason.

--- a/src/builders.test.ts
+++ b/src/builders.test.ts
@@ -589,4 +589,46 @@ describe("builders", () => {
       expect(result.usage).toBe("Link color");
     });
   });
+
+  describe("preview hint (object type argument)", () => {
+    test("group stamps every token with the preview kind", () => {
+      const result = group(
+        { type: "elevation", preview: "shadow" },
+        {
+          card: "0 1px 2px #0003",
+          modal: "0 8px 16px #0003",
+        },
+      );
+      expect(result.every((t) => t.preview === "shadow")).toBe(true);
+      // type is still the bare string — grouping/DTCG/plugins are unaffected.
+      expect(result.every((t) => t.type === "elevation")).toBe(true);
+    });
+
+    test("a bare string type argument leaves preview undefined", () => {
+      const result = group("color", { primary: "#0066cc" });
+      expect(result[0]!.preview).toBeUndefined();
+    });
+
+    test("scale stamps preview on the numeric-array path", () => {
+      const result = scale({ type: "ring", preview: "borderWidth" }, [1, 2, 4], {
+        names: ["thin", "medium", "thick"],
+      });
+      expect(result.every((t) => t.preview === "borderWidth")).toBe(true);
+    });
+
+    test("scale stamps preview on the object path (via group)", () => {
+      const result = scale({ type: "ring", preview: "borderWidth" }, { thin: "1px", thick: "4px" });
+      expect(result.every((t) => t.preview === "borderWidth")).toBe(true);
+    });
+
+    test("composite stamps preview on each token", () => {
+      const result = composite(
+        { type: "ornament", preview: "typography" },
+        {
+          h1: { fontFamily: "Rubik", fontSize: "2rem" },
+        },
+      );
+      expect(result[0]!.preview).toBe("typography");
+    });
+  });
 });

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -13,10 +13,25 @@ import type {
   Token,
   TokenInput,
   TokenInputObject,
+  TypeSpec,
   TokenValue,
 } from "./Token.js";
 
 const arrayKeys = new Set(Object.getOwnPropertyNames(Array.prototype));
+
+/**
+ * A builder's first argument: a bare type string, or a {@link TypeSpec}
+ * object carrying a documentation-only `preview` hint alongside the type.
+ */
+export type TypeArg = string | TypeSpec;
+
+const normalizeTypeArg = (arg: TypeArg): TypeSpec =>
+  typeof arg === "string" ? { type: arg } : arg;
+
+// Attach the optional `preview` hint to a built token. Kept as a helper so
+// the three group builders stamp it identically and only when present.
+const withPreview = <T extends Token>(token: T, preview: TypeSpec["preview"]): T =>
+  preview ? { ...token, preview } : token;
 
 // Numeric-string keys (e.g. "0", "1") are valid array indices — defining a
 // property at that key overwrites the array slot, corrupting iteration.
@@ -78,12 +93,21 @@ const resolveCompositeInput = (name: string, input: CompositeTokenInput): Omit<T
  * - A tuple: `['#0066cc', 'Primary brand color']`
  * - An object: `{ value: '#0066cc', usage: 'Primary brand color', modes: { dark: '#3399ff' } }`
  *
+ * The first argument is normally the type string, but can be an object to
+ * attach a documentation-only `preview` hint — useful when a semantic type
+ * name wouldn't be recognized by the doc generators' inference:
+ *
  * @example
  * ```ts
  * const colors = group('color', {
  *   primary: '#0066cc',
  *   secondary: ['#cc6600', 'Secondary brand color'],
  *   surface: { value: '#ffffff', modes: { dark: '#1a1a1a' } },
+ * });
+ *
+ * // Name the group whatever you like; tell the docs how to picture it:
+ * const elevation = group({ type: 'elevation', preview: 'shadow' }, {
+ *   card: new BoxShadow(0, 1, 2, 0, '#0003'),
  * });
  * ```
  */
@@ -95,18 +119,25 @@ export type TokenGroup<E extends Record<string, TokenInput>> = Token[] & {
 };
 
 export const group = <E extends Record<string, TokenInput>>(
-  type: string,
+  typeArg: TypeArg,
   entries: E,
 ): TokenGroup<E> => {
   if (typeof entries !== "object" || entries === null || Array.isArray(entries)) {
     throw new TypeError(`group(): entries must be a plain object, got ${typeof entries}`);
   }
 
-  const result = Object.entries(entries).map(([name, input]) => ({
-    ...resolveTokenInput(name, input),
-    type,
-    group: type,
-  }));
+  const { type, preview } = normalizeTypeArg(typeArg);
+
+  const result = Object.entries(entries).map(([name, input]) =>
+    withPreview(
+      {
+        ...resolveTokenInput(name, input),
+        type,
+        group: type,
+      },
+      preview,
+    ),
+  );
 
   for (const token of result) {
     if (arrayKeys.has(token.name)) {
@@ -143,13 +174,15 @@ export const group = <E extends Record<string, TokenInput>>(
  * ```
  */
 export const scale = (
-  type: string,
+  typeArg: TypeArg,
   values: Record<string, TokenInput> | number[],
   options?: { names?: string[]; transform?: (n: number) => TokenValue; usage?: string },
 ): Token[] => {
   if (!Array.isArray(values) && (typeof values !== "object" || values === null)) {
     throw new TypeError(`scale(): values must be a plain object or array, got ${typeof values}`);
   }
+
+  const { type, preview } = normalizeTypeArg(typeArg);
 
   if (Array.isArray(values)) {
     const { names, transform = (n: number) => n, usage } = options ?? {};
@@ -161,11 +194,12 @@ export const scale = (
         token.usage = usage;
       }
 
-      return token;
+      return withPreview(token, preview);
     });
   }
 
-  return group(type, values);
+  // Re-pass the original arg so `group` applies the same preview stamping.
+  return group(typeArg, values);
 };
 
 /**
@@ -179,9 +213,16 @@ export const scale = (
  * });
  * ```
  */
-export const composite = (type: string, entries: Record<string, CompositeTokenInput>): Token[] =>
-  Object.entries(entries).map(([name, input]) => {
-    const token = { ...resolveCompositeInput(name, input), type, group: type };
+export const composite = (
+  typeArg: TypeArg,
+  entries: Record<string, CompositeTokenInput>,
+): Token[] => {
+  const { type, preview } = normalizeTypeArg(typeArg);
+  return Object.entries(entries).map(([name, input]) => {
+    const token = withPreview(
+      { ...resolveCompositeInput(name, input), type, group: type },
+      preview,
+    );
     const compositeValue = token.value;
 
     if (
@@ -206,6 +247,7 @@ export const composite = (type: string, entries: Record<string, CompositeTokenIn
 
     return token;
   });
+};
 
 // TODO: consider supporting custom text colors beyond black/white for cases where neither meets WCAG AA
 /**

--- a/src/storybook/components.tsx
+++ b/src/storybook/components.tsx
@@ -12,8 +12,17 @@ type ElOrNull = React.JSX.Element | null;
 
 // ─── Theme ───────────────────────────────────────────────────
 
-const themeStyles = `
-.teikn-sb {
+type ColorScheme = "auto" | "light" | "dark";
+
+// Palette-independent vars (fonts, accents, radius). These never change
+// between light and dark, so they live on the root unconditionally.
+const constants = `
+  --tkn-mono: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+  --tkn-accent: #0066cc;
+  --tkn-accent-light: #38bdf8;
+  --tkn-radius: 8px;`;
+
+const lightVars = `
   --tkn-bg: #ffffff;
   --tkn-bg-subtle: #f5f5f5;
   --tkn-bg-muted: #fafafa;
@@ -21,27 +30,12 @@ const themeStyles = `
   --tkn-text: #1a1a1a;
   --tkn-text-secondary: #666666;
   --tkn-text-muted: #999999;
-  --tkn-mono: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
-  --tkn-accent: #0066cc;
-  --tkn-accent-light: #38bdf8;
-  --tkn-radius: 8px;
-  color-scheme: light dark;
-}
+  --tkn-shadow-stage: #f4f4f6;`;
 
-@media (prefers-color-scheme: dark) {
-  .teikn-sb {
-    --tkn-bg: #1e1e1e;
-    --tkn-bg-subtle: #2a2a2a;
-    --tkn-bg-muted: #252525;
-    --tkn-border: #3a3a3a;
-    --tkn-text: #e0e0e0;
-    --tkn-text-secondary: #a0a0a0;
-    --tkn-text-muted: #777777;
-  }
-}
-
-[data-theme="dark"] .teikn-sb,
-.dark .teikn-sb {
+// `--tkn-shadow-stage` stays light even in dark mode: box-shadows are
+// semi-transparent black and only read against a light surface, so shadow
+// swatches sit on their own light stage regardless of the theme.
+const darkVars = `
   --tkn-bg: #1e1e1e;
   --tkn-bg-subtle: #2a2a2a;
   --tkn-bg-muted: #252525;
@@ -49,8 +43,37 @@ const themeStyles = `
   --tkn-text: #e0e0e0;
   --tkn-text-secondary: #a0a0a0;
   --tkn-text-muted: #777777;
+  --tkn-shadow-stage: #e6e6ea;`;
+
+// The wrapper paints its OWN background/color so the whole story surface is
+// themed — without this, dark cards float on Storybook's white canvas.
+const rootSurface = `
+  background: var(--tkn-bg);
+  color: var(--tkn-text);
+  min-height: 100%;
+  padding: 1.5rem;
+  box-sizing: border-box;`;
+
+const buildThemeStyles = (colorScheme: ColorScheme): string => {
+  if (colorScheme === "light") {
+    return `.teikn-sb {${constants}${lightVars}${rootSurface}\n  color-scheme: light;\n}`;
+  }
+  if (colorScheme === "dark") {
+    return `.teikn-sb {${constants}${darkVars}${rootSurface}\n  color-scheme: dark;\n}`;
+  }
+  return `.teikn-sb {${constants}${lightVars}${rootSurface}
+  color-scheme: light dark;
 }
-`;
+
+@media (prefers-color-scheme: dark) {
+  .teikn-sb {${darkVars}
+  }
+}
+
+[data-theme="dark"] .teikn-sb,
+.dark .teikn-sb {${darkVars}
+}`;
+};
 
 // ─── Primitives ──────────────────────────────────────────────
 
@@ -83,9 +106,15 @@ const mono: React.CSSProperties = {
 
 // ─── Theme wrapper ───────────────────────────────────────────
 
-export const TokenStory = ({ children }: { children: React.ReactNode }): El => (
+export const TokenStory = ({
+  children,
+  colorScheme = "auto",
+}: {
+  children: React.ReactNode;
+  colorScheme?: ColorScheme;
+}): El => (
   <div className="teikn-sb">
-    <style>{themeStyles}</style>
+    <style>{buildThemeStyles(colorScheme)}</style>
     {children}
   </div>
 );
@@ -140,19 +169,24 @@ export const SpacingBar = ({ name, value }: { name: string; value: string }): El
 // ─── Shadow ──────────────────────────────────────────────────
 
 export const ShadowBox = ({ name, value }: { name: string; value: string }): El => (
-  <div style={{ ...card, padding: "1rem", width: 200, textAlign: "center" }}>
-    <div
-      style={{
-        width: 88,
-        height: 88,
-        background: "var(--tkn-bg)",
-        borderRadius: 8,
-        margin: "0.75rem auto",
-        boxShadow: value,
-      }}
-    />
-    <div style={{ fontWeight: 600, fontSize: "0.875rem" }}>{name}</div>
-    <div style={{ ...mono, marginTop: "0.25rem", wordBreak: "break-all" }}>{value}</div>
+  <div style={{ ...card, padding: 0, width: 200, textAlign: "center", overflow: "hidden" }}>
+    {/* Light stage so dark, semi-transparent shadows stay visible in any theme */}
+    <div style={{ background: "var(--tkn-shadow-stage)", padding: "1.75rem 1rem" }}>
+      <div
+        style={{
+          width: 88,
+          height: 88,
+          background: "#ffffff",
+          borderRadius: 8,
+          margin: "0 auto",
+          boxShadow: value,
+        }}
+      />
+    </div>
+    <div style={{ padding: "0.875rem" }}>
+      <div style={{ fontWeight: 600, fontSize: "0.875rem" }}>{name}</div>
+      <div style={{ ...mono, marginTop: "0.25rem", wordBreak: "break-all" }}>{value}</div>
+    </div>
   </div>
 );
 
@@ -257,6 +291,42 @@ export const BorderDemo = ({
     </div>
   );
 };
+
+// ─── Border Width ────────────────────────────────────────────
+
+export const BorderWidthDemo = ({ name, value }: { name: string; value: string }): El => (
+  <div style={{ ...card, padding: "1rem", marginBottom: "0.75rem" }}>
+    <div style={label}>
+      {name} <code style={code}>{value}</code>
+    </div>
+    <div
+      style={{
+        height: 56,
+        borderRadius: 6,
+        background: "var(--tkn-bg-muted)",
+        border: `${value} solid var(--tkn-accent)`,
+      }}
+    />
+  </div>
+);
+
+// ─── Border Style ────────────────────────────────────────────
+
+export const BorderStyleDemo = ({ name, value }: { name: string; value: string }): El => (
+  <div style={{ ...card, padding: "1rem", marginBottom: "0.75rem" }}>
+    <div style={label}>
+      {name} <code style={code}>{value}</code>
+    </div>
+    <div
+      style={{
+        height: 56,
+        borderRadius: 6,
+        background: "var(--tkn-bg-muted)",
+        border: `3px ${value} var(--tkn-accent)`,
+      }}
+    />
+  </div>
+);
 
 // ─── Border Radius ───────────────────────────────────────────
 

--- a/src/storybook/components.tsx
+++ b/src/storybook/components.tsx
@@ -5,7 +5,7 @@
  * They use CSS custom properties for theming and respond to
  * Storybook's dark mode automatically.
  */
-import React from "react";
+import * as React from "react";
 
 type El = React.JSX.Element;
 type ElOrNull = React.JSX.Element | null;

--- a/src/storybook/index.ts
+++ b/src/storybook/index.ts
@@ -1,6 +1,8 @@
 export {
   BreakpointBar,
   BorderDemo,
+  BorderStyleDemo,
+  BorderWidthDemo,
   DurationBar,
   FontSample,
   GradientSwatch,

--- a/src/type-classifiers.test.ts
+++ b/src/type-classifiers.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+
+import { classifyTokenType, resolvePreviewKind } from "./type-classifiers.js";
+
+describe("classifyTokenType", () => {
+  test("maps canonical kebab-case types to their kind", () => {
+    expect(classifyTokenType("color")).toBe("color");
+    expect(classifyTokenType("radius")).toBe("borderRadius");
+    expect(classifyTokenType("border-radius")).toBe("borderRadius");
+    expect(classifyTokenType("border-width")).toBe("borderWidth");
+    expect(classifyTokenType("border-style")).toBe("borderStyle");
+    expect(classifyTokenType("z-index")).toBe("zLayer");
+    expect(classifyTokenType("z-layer")).toBe("zLayer");
+    expect(classifyTokenType("line-height")).toBe("lineHeight");
+  });
+
+  test("is case- and separator-tolerant (agent-friendly variance)", () => {
+    expect(classifyTokenType("borderRadius")).toBe("borderRadius");
+    expect(classifyTokenType("border_radius")).toBe("borderRadius");
+    expect(classifyTokenType("Color")).toBe("color");
+  });
+
+  test("resolves overlaps by priority — specific before broad", () => {
+    // /spacing/ would also match "letter-spacing"; letterSpacing must win.
+    expect(classifyTokenType("letter-spacing")).toBe("letterSpacing");
+    expect(classifyTokenType("spacing")).toBe("spacing");
+    // border-* trio must win over bare border.
+    expect(classifyTokenType("border-width")).not.toBe("border");
+    expect(classifyTokenType("border")).toBe("border");
+  });
+
+  test("falls back to 'table' for unrecognized types", () => {
+    expect(classifyTokenType("widgetThing")).toBe("table");
+    expect(classifyTokenType("")).toBe("table");
+  });
+});
+
+describe("resolvePreviewKind", () => {
+  test("an explicit preview hint overrides inference", () => {
+    expect(resolvePreviewKind({ type: "elevation", preview: "shadow" })).toBe("shadow");
+    // A type that would infer to borderRadius, overridden to size.
+    expect(resolvePreviewKind({ type: "radius", preview: "size" })).toBe("size");
+  });
+
+  test("falls back to type inference when no hint is present", () => {
+    expect(resolvePreviewKind({ type: "radius" })).toBe("borderRadius");
+    expect(resolvePreviewKind({ type: "mystery" })).toBe("table");
+  });
+});

--- a/src/type-classifiers.ts
+++ b/src/type-classifiers.ts
@@ -1,4 +1,4 @@
-import type { Token } from "./Token.js";
+import type { PreviewKind, Token } from "./Token.js";
 
 // ─── First-class value brand ─────────────────────────────────────
 // Every first-class value type class carries a `__teikn_fcv__`
@@ -20,7 +20,11 @@ export const isFontSizeType = (type: string): boolean => /font[-_]?size/i.test(t
 export const isFontFamilyType = (type: string): boolean => /font[-_]?family/i.test(type);
 export const isFontWeightType = (type: string): boolean => /font[-_]?weight/i.test(type);
 export const isTypographyType = (type: string): boolean => /^typography$/i.test(type);
-export const isBorderRadiusType = (type: string): boolean => /border[-_]?radius/i.test(type);
+// Matches both the prefixed `border-radius` and the bare `radius` type
+// that many token sets use (e.g. `radiusSm`, `radiusPill`).
+export const isBorderRadiusType = (type: string): boolean => /(?:border[-_]?)?radius/i.test(type);
+export const isBorderWidthType = (type: string): boolean => /border[-_]?width/i.test(type);
+export const isBorderStyleType = (type: string): boolean => /border[-_]?style/i.test(type);
 export const isBorderType = (type: string): boolean => /^border$/i.test(type);
 export const isShadowType = (type: string): boolean => /shadow/i.test(type);
 export const isDurationType = (type: string): boolean => /duration/i.test(type);
@@ -35,6 +39,52 @@ export const isSizeType = (type: string): boolean => /^size$/i.test(type);
 export const isAspectRatioType = (type: string): boolean => /aspect[-_]?ratio/i.test(type);
 export const isZLayerType = (type: string): boolean => /z[-_]?(layer|index)/i.test(type);
 export const isTransitionType = (type: string): boolean => /^transition$/i.test(type);
+
+// ─── Type → preview-kind classification ──────────────────────
+// The single, ordered source of truth for turning a token's `type` string
+// into a visualization kind. First match wins, so SPECIFIC patterns must
+// precede BROAD ones (e.g. letter-spacing before spacing, the border-* trio
+// before bare border). Centralizing the priority here means the doc
+// generators no longer each re-encode (and drift on) the ordering.
+
+const previewRules: ReadonlyArray<readonly [PreviewKind, RegExp]> = [
+  ["color", /^color$/i],
+  ["typography", /^typography$/i],
+  ["fontSize", /font[-_]?size/i],
+  ["fontFamily", /font[-_]?family/i],
+  ["fontWeight", /font[-_]?weight/i],
+  ["letterSpacing", /letter[-_]?spacing/i],
+  ["lineHeight", /line[-_]?height/i],
+  ["borderWidth", /border[-_]?width/i],
+  ["borderStyle", /border[-_]?style/i],
+  ["borderRadius", /(?:border[-_]?)?radius/i],
+  ["border", /^border$/i],
+  ["shadow", /shadow/i],
+  ["duration", /duration/i],
+  ["timing", /timing|easing/i],
+  ["spacing", /spacing|gap/i],
+  ["gradient", /gradient/i],
+  ["opacity", /^opacity$/i],
+  ["breakpoint", /breakpoint/i],
+  ["size", /^size$/i],
+  ["aspectRatio", /aspect[-_]?ratio/i],
+  ["zLayer", /z[-_]?(layer|index)/i],
+  ["transition", /^transition$/i],
+];
+
+/**
+ * Infer a {@link PreviewKind} from a token's `type` string. Falls back to
+ * `"table"` (a generic name/value table) when nothing matches.
+ */
+export const classifyTokenType = (type: string): PreviewKind =>
+  previewRules.find(([, re]) => re.test(type))?.[0] ?? "table";
+
+/**
+ * Resolve how a token should be pictured: an explicit `preview` hint wins,
+ * otherwise infer from `type`. This is the entry point the doc generators use.
+ */
+export const resolvePreviewKind = (token: Pick<Token, "type" | "preview">): PreviewKind =>
+  token.preview ?? classifyTokenType(token.type);
 
 // ─── Shared helpers ──────────────────────────────────────────
 

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const version = "2.0.0-beta.2";
+export const version = "2.0.0-beta.3";


### PR DESCRIPTION
This started as a handful of Storybook bugs and turned into a small cleanup of how we figure out what a token *is* for documentation purposes.

### The bugs

- **Dark mode looked broken.** The `.teikn-sb` wrapper defined all the dark palette variables but never actually painted its own background/color, so you'd get dark cards floating on Storybook's white canvas. It now themes the whole surface (and the story layout is `fullscreen` so there's no white frame around it).
- **Shadow swatches were invisible in dark mode.** Box-shadows are semi-transparent black, so they only read against a light surface. The swatch now sits on its own light "stage" regardless of theme.
- **`border-width`, `border-style`, and `radius` tokens rendered as a plain name/value table.** There was no component for the first two, and the radius classifier only matched `border-radius`, not a bare `radius`. Added `BorderWidthDemo`/`BorderStyleDemo` and broadened the matching.

### The cleanup

While fixing the radius matching I noticed the classification was pretty fragile: the same priority-ordered regex ladder was hand-maintained in three places (Storybook's `classifyType`, Html's `renderVisualization` and `vizClassForType`), and they'd already drifted — Html didn't handle `z-index` or the border-width/style types that Storybook did.

So I pulled it into one ordered table (`classifyTokenType`) that both generators read through `resolvePreviewKind`. The generators now switch on the resulting kind via an exhaustively-checked map, so adding a kind is a compile error until you wire it everywhere.

On top of that, you can now override the inferred visualization at declaration time:

```ts
// name the group whatever you want; tell the docs how to picture it
group({ type: "elevation", preview: "shadow" }, { card: shadow1, modal: shadow2 });
```

`preview` is documentation-only — it never touches the CSS/SCSS/JS/DTCG output. When it's absent we fall back to inferring from `type` exactly like before, so this is fully additive.

### Also in here

A drive-by fix for `Html`'s `header()` crashing when no `dateFn` is passed — it asserted `dateFn!()` even though the option is optional. Every other generator already guards this; Html got missed back in #34. This was blocking `generate-example`.

### Testing

`bun test` (1968 pass) and `vitest` both green; lint and format clean. The classifier rework is behavior-preserving — no snapshot changes from it — so existing token sets render identically; the only visible differences are the bug fixes above.
