### PR TITLE
Add buildPlatforms for base + per-platform delta builds

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -14,6 +14,7 @@ export * from './src/Generators/index.js';
 export * from './src/Plugins/index.js';
 export * from './src/Token.js';
 export * from './src/builders.js';
+export * from './src/build-platforms.js';
 export * from './src/type-classifiers.js';
 export { resolveReferences } from './src/resolve.js';
 export { validate } from './src/validate.js';

--- a/src/build-platforms.test.ts
+++ b/src/build-platforms.test.ts
@@ -1,0 +1,80 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { buildPlatforms } from './build-platforms.js';
+import { group } from './builders.js';
+import { CssVars } from './Generators/CssVars.js';
+import { tokenSet } from './TokenSet.js';
+
+const tmpDir = path.join(os.tmpdir(), `teikn-platforms-${Date.now()}`);
+
+afterAll(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+const base = tokenSet('base', group('size', { nav: '44px', gap: '8px' }));
+
+// Mobile re-declares only the one token that differs.
+const mobile = tokenSet('mobile', group('size', { nav: '56px' }));
+
+const read = (platform: string): string =>
+  fs.readFileSync(path.join(tmpDir, platform, 'tokens.css'), 'utf8');
+
+describe('buildPlatforms', () => {
+  test('emits one flat artifact per platform with deltas collapsed in', async () => {
+    const results = await buildPlatforms({
+      base,
+      platforms: { web: null, mobile },
+      generators: () => [new CssVars({ filename: 'tokens', version: 'test' })],
+      outDir: tmpDir,
+    });
+
+    expect([...results.keys()].toSorted()).toEqual(['mobile', 'web']);
+
+    const web = read('web');
+    const mob = read('mobile');
+
+    // The overridden token differs per platform...
+    expect(web).toContain('44px');
+    expect(web).not.toContain('56px');
+    expect(mob).toContain('56px');
+    expect(mob).not.toContain('44px');
+
+    // ...while untouched tokens fall through identically.
+    expect(web).toContain('8px');
+    expect(mob).toContain('8px');
+
+    // Build-time collapse: no runtime mode artifacts.
+    expect(mob).not.toContain('[data-theme');
+  });
+
+  test('null delta uses the base unchanged', async () => {
+    const results = await buildPlatforms({
+      base,
+      platforms: { web: null },
+      generators: () => [new CssVars({ filename: 'tokens', version: 'test' })],
+      outDir: tmpDir,
+    });
+
+    expect(results.get('web')?.files).toHaveLength(1);
+    expect(read('web')).toContain('44px');
+  });
+
+  test('the generator factory is invoked once per platform with its name', async () => {
+    const seen: string[] = [];
+    await buildPlatforms({
+      base,
+      platforms: { web: null, mobile },
+      generators: platform => {
+        seen.push(platform);
+
+        return [new CssVars({ filename: 'tokens', version: 'test' })];
+      },
+      outDir: tmpDir,
+    });
+
+    expect(seen.toSorted()).toEqual(['mobile', 'web']);
+  });
+});

--- a/src/build-platforms.ts
+++ b/src/build-platforms.ts
@@ -1,0 +1,75 @@
+import path from 'node:path';
+
+import type { Generator } from './Generators/Generator.js';
+import type { Plugin } from './Plugins/index.js';
+import { Teikn } from './Teikn.js';
+import type { TransformResult } from './Teikn.js';
+import type { ThemeLayer } from './Token.js';
+import { composeTokenSets } from './TokenSet.js';
+import type { TokenSet } from './TokenSet.js';
+
+export type PlatformBuild = {
+  /** The base token set every platform starts from. */
+  base: TokenSet;
+  /**
+   * Platform name → its delta token set. `null` means "use base unchanged"
+   * (e.g. the canonical web build). A delta overrides the base by qualified
+   * key (`group.name`) via {@link composeTokenSets} — a build-time collapse,
+   * not a runtime mode: the platform's artifact carries flat values with no
+   * `modes` block or `[data-theme]` selector.
+   */
+  platforms: Record<string, TokenSet | null>;
+  /**
+   * Fresh generator instances per platform. A factory rather than an array
+   * because each {@link Teikn} build binds its generators to itself (via
+   * `siblings`), so sharing instances across builds would cross-wire them.
+   * Receives the platform name so a platform can emit a different set
+   * (e.g. a Swift generator for iOS, CSS for web).
+   */
+  generators: (platform: string) => Generator[];
+  /** Optional per-platform plugins, built fresh per platform for the same reason. */
+  plugins?: (platform: string) => Plugin[];
+  /** Optional per-platform theme layers, if you mix modes into a platform build. */
+  themes?: (platform: string) => ThemeLayer[];
+  /** Output root. Each platform writes to `${outDir}/${platform}`. */
+  outDir: string;
+};
+
+/**
+ * Build one flat artifact set per platform from a shared base plus per-platform
+ * deltas — the "base tokens, change some for another platform" workflow.
+ *
+ * Runs platforms sequentially (builds are fast; concurrency can be added later
+ * without changing the signature). Returns each platform's {@link TransformResult}
+ * keyed by platform name.
+ *
+ * @example
+ * ```ts
+ * await buildPlatforms({
+ *   base,
+ *   platforms: { web: null, mobile },
+ *   generators: () => [new JavaScript({ filename: "tokens" }), new CssVars({ filename: "tokens" })],
+ *   outDir: "generated",
+ * });
+ * ```
+ */
+export const buildPlatforms = ({
+  base,
+  platforms,
+  generators,
+  plugins,
+  themes,
+  outDir,
+}: PlatformBuild): Promise<Map<string, TransformResult>> =>
+  Object.entries(platforms).reduce(async (acc, [platform, delta]) => {
+    const results = await acc;
+    const tokens = delta ? composeTokenSets(base, delta) : base.tokens;
+    const writer = new Teikn({
+      outDir: path.join(outDir, platform),
+      generators: generators(platform),
+      ...(plugins ? { plugins: plugins(platform) } : {}),
+      ...(themes ? { themes: themes(platform) } : {}),
+    });
+
+    return results.set(platform, await writer.transform(tokens));
+  }, Promise.resolve(new Map<string, TransformResult>()));

--- a/src/ensure-directory.ts
+++ b/src/ensure-directory.ts
@@ -15,7 +15,6 @@ export const ensureDirectory = async (dirPath: string): Promise<void> => {
 
     try {
       await fs.promises.mkdir(dir, { mode: 0o755, recursive: true });
-      console.log(`Created ${dir}.`);
 
       return Promise.resolve();
     } catch (e: unknown) {


### PR DESCRIPTION
## What

Adds `buildPlatforms`, a helper for generating a separate set of token artifacts per platform (web, iOS, Android, Typst, …) from one shared base plus small per-platform overrides.

```ts
import { buildPlatforms, tokenSet, group, JavaScript, CssVars } from "teikn";

const base = tokenSet("base", /* groups… */);
const mobile = tokenSet("mobile", group("size", { nav: "56px" })); // only what differs

await buildPlatforms({
  base,
  platforms: { web: null, mobile },   // null = use the base unchanged
  generators: (platform) => [new JavaScript({ filename: "tokens" }), new CssVars({ filename: "tokens" })],
  outDir: "generated",                // → generated/web/…, generated/mobile/…
});
// → Map<platform, TransformResult>
```

## Why

You can already express "base, but override a few tokens" with `composeTokenSets` (last-wins merge by qualified `group.name` key). What was missing was the orchestration around it: to emit per-platform output you had to write a near-identical `new Teikn({ outDir, generators }).transform(composeTokenSets(base, delta))` block for every platform, and get a couple of non-obvious details right each time (see below). `buildPlatforms` is that loop, done once.

## Behavior and design choices

**Overrides are collapsed at build time, not emitted as modes.** Each platform's delta is merged into the base into flat values — the generated files have no `modes` block and no `[data-theme]` selector. This is the right model when "platform" means a different *renderer* (iOS, Typst) that can't read a runtime theme attribute: the override is baked in. (Teikn's existing modes/themes are still the tool for runtime toggles like dark mode *within* one artifact — that's a different axis.)

**`generators` is a factory `(platform) => Generator[]`, not an array.** Two reasons:
1. A generator instance is bound to a single `Teikn` build through its `siblings` list — that's how `Html` and `Storybook` discover the other generators to cross-reference (e.g. Storybook picks which runtime module to import). Reusing one instance across builds would cross-wire them. A factory makes "fresh instances per build" the only possibility.
2. Passing the platform name lets a platform return a *different* generator set — e.g. a Swift generator for iOS, CSS for web — which an array can't express.

**Sequential.** Platform builds are fast and each writes to its own `outDir/<platform>` directory, so this could parallelize later without an API change. Left sequential for now for predictable ordering and error reporting.

**Returns `Map<platform, TransformResult>`** so callers can inspect what was written (or assert on it in tests) rather than it being write-only.

**Optional `plugins(platform)` / `themes(platform)` factories**, mirroring `generators`, for the same fresh-per-build reason.

It's a free function exported from the package root rather than a `Teikn` static — `Teikn` stays a single-build unit and this composes it.

## Also in here

Removed a `console.log("Created <dir>.")` in `ensureDirectory` (separate commit). Library code shouldn't write to stdout, and it would otherwise print once per platform on every build. Nothing asserts on it and the CLI doesn't depend on it.

## Testing

New `build-platforms.test.ts` builds `web` + `mobile` to a temp dir and verifies: the overridden token differs per platform while untouched tokens fall through identically, `null` uses the base unchanged, the output contains no `[data-theme]` (confirming build-time collapse), and the generator factory is invoked once per platform with its name. Full suite green (1971 tests); lint and format clean.
