### PR TITLE
Clean up the generated JavaScript and TypeScript output

### DIFF
--- a/src/Generators/JavaScript.ts
+++ b/src/Generators/JavaScript.ts
@@ -119,7 +119,14 @@ export class JavaScript extends Generator<JavaScriptOpts> {
           mapEntries,
           `};`,
           `${decl} ${groupName} = (name) => {`,
-          `  if (!(name in _${groupName})) throw new Error(\`Unknown ${groupName} token: \${name}\`);`,
+          // `hasOwnProperty.call` (not `name in`) so inherited keys like
+          // "toString"/"constructor" don't sneak past the guard. Spelled out
+          // rather than `Object.hasOwn` (ES2022) because this runs in the
+          // consumer's environment, which may predate it. Braces match the
+          // project's control-flow style and keep the output lint-clean.
+          `  if (!Object.prototype.hasOwnProperty.call(_${groupName}, name)) {`,
+          `    throw new Error(\`Unknown ${groupName} token: \${name}\`);`,
+          `  }`,
           `  return _${groupName}[name];`,
           `};`,
         ].join(EOL);

--- a/src/Generators/JavaScript.vitest.snap
+++ b/src/Generators/JavaScript.vitest.snap
@@ -27,14 +27,18 @@ const _color = {
   secondary: tokens.colorSecondary,
 };
 export const color = (name) => {
-  if (!(name in _color)) throw new Error(\`Unknown color token: \${name}\`);
+  if (!Object.prototype.hasOwnProperty.call(_color, name)) {
+    throw new Error(\`Unknown color token: \${name}\`);
+  }
   return _color[name];
 };
 const _spacing = {
   sm: tokens.spacingSm,
 };
 export const spacing = (name) => {
-  if (!(name in _spacing)) throw new Error(\`Unknown spacing token: \${name}\`);
+  if (!Object.prototype.hasOwnProperty.call(_spacing, name)) {
+    throw new Error(\`Unknown spacing token: \${name}\`);
+  }
   return _spacing[name];
 };
 

--- a/src/Generators/TypeScript.test.ts
+++ b/src/Generators/TypeScript.test.ts
@@ -51,8 +51,8 @@ describe("TypeScript meta generator", () => {
     const files = new TypeScript({ dateFn: fixedDate }).generateFiles(sampleTokens);
     const dts = files.get("tokens.d.ts")!;
     expect(dts).toContain("export declare const tokens: {");
-    expect(dts).toContain('readonly colorPrimary: "#0066cc";');
-    expect(dts).toContain('readonly colorSecondary: "#999999";');
+    expect(dts).toContain("readonly colorPrimary: '#0066cc';");
+    expect(dts).toContain("readonly colorSecondary: '#999999';");
   });
 
   test("module: 'cjs' switches the runtime file to .cjs + module.exports and declarations to .d.cts", () => {
@@ -153,7 +153,7 @@ describe("TypeScript meta generator", () => {
 
     expect(mjs).toContain("#FF0000");
     // Declarations see the pre-plugin literal.
-    expect(dts).toContain('"#ff0000"');
+    expect(dts).toContain("'#ff0000'");
     expect(dts).not.toContain("#FF0000");
   });
 

--- a/src/Generators/TypeScript.vitest.snap
+++ b/src/Generators/TypeScript.vitest.snap
@@ -17,15 +17,15 @@ export declare const tokens: {
   /**
    *  Type: color
    */
-  readonly primary: "#0066cc";
+  readonly primary: '#0066cc';
   /**
    *  Type: color
    */
-  readonly accent: "#ff6600";
+  readonly accent: '#ff6600';
   /**
    *  Type: spacing
    */
-  readonly sm: "0.5rem";
+  readonly sm: '0.5rem';
 };
 
 export type TokenNames = {
@@ -66,14 +66,18 @@ const _color = {
   accent: tokens.accent,
 };
 export const color = (name) => {
-  if (!(name in _color)) throw new Error(\`Unknown color token: \${name}\`);
+  if (!Object.prototype.hasOwnProperty.call(_color, name)) {
+    throw new Error(\`Unknown color token: \${name}\`);
+  }
   return _color[name];
 };
 const _spacing = {
   sm: tokens.sm,
 };
 export const spacing = (name) => {
-  if (!(name in _spacing)) throw new Error(\`Unknown spacing token: \${name}\`);
+  if (!Object.prototype.hasOwnProperty.call(_spacing, name)) {
+    throw new Error(\`Unknown spacing token: \${name}\`);
+  }
   return _spacing[name];
 };
 

--- a/src/Generators/TypeScriptDeclarations.test.ts
+++ b/src/Generators/TypeScriptDeclarations.test.ts
@@ -21,6 +21,23 @@ describe("TypeScriptDeclarations generator", () => {
     expect(new Generator({ ...testOpts, groups: true }).generate(tokens)).toMatchSnapshot();
   });
 
+  test("group accessors widen their return to the primitive type", () => {
+    const tokens: Token[] = [
+      { name: "zIndexModal", type: "z-index", value: 400 },
+      { name: "zIndexToast", type: "z-index", value: 500 },
+      { name: "colorPrimary", type: "color", value: "#0066cc" },
+    ];
+    const out = new Generator({ ...testOpts, groups: true }).generate(tokens);
+    // A numeric group returns `number` — not `string`, not a literal union.
+    expect(out).toContain("export declare const zIndex: (name: 'modal' | 'toast') => number;");
+    expect(out).not.toContain("=> 400");
+    // A string group returns `string`.
+    expect(out).toContain("export declare const color: (name: 'primary') => string;");
+    // The tokens object still carries precise literals for static access.
+    expect(out).toContain("readonly zIndexModal: 400;");
+    expect(out).toContain("readonly colorPrimary: '#0066cc';");
+  });
+
   test("describe includes group accessor usage when groups enabled", () => {
     const info = new Generator({ dateFn: fixedDate, groups: true }).describe();
     expect(info.format).toBe("TypeScript Declarations");
@@ -79,7 +96,7 @@ describe("TypeScriptDeclarations generator", () => {
       nameTransformer: (name: string) => name.replace(/([a-z])([A-Z])/g, "$1-$2").toLowerCase(),
     }).generate([{ name: "colorPrimary", type: "color", value: "#ffffff" }]);
 
-    expect(output).toContain("'color-primary': \"#ffffff\"");
+    expect(output).toContain("'color-primary': '#ffffff'");
   });
 });
 
@@ -88,7 +105,7 @@ describe("TypeScriptDeclarations: literal types (default)", () => {
 
   test("string values become literal string types", () => {
     const output = gen.generate([{ name: "primary", type: "color", value: "#0066cc" }]);
-    expect(output).toContain('readonly primary: "#0066cc";');
+    expect(output).toContain("readonly primary: '#0066cc';");
   });
 
   test("number values become literal number types", () => {
@@ -120,14 +137,14 @@ describe("TypeScriptDeclarations: literal types (default)", () => {
         value: { fontFamily: "Inter", fontSize: "16px" },
       },
     ]);
-    expect(output).toContain('readonly fontFamily: "Inter"');
-    expect(output).toContain('readonly fontSize: "16px"');
+    expect(output).toContain("readonly fontFamily: 'Inter'");
+    expect(output).toContain("readonly fontSize: '16px'");
   });
 
   test("top-level tokens declaration uses `export declare const` with readonly fields", () => {
     const output = gen.generate([{ name: "primary", type: "color", value: "#0066cc" }]);
     expect(output).toContain("export declare const tokens: {");
-    expect(output).toContain('readonly primary: "#0066cc";');
+    expect(output).toContain("readonly primary: '#0066cc';");
   });
 });
 

--- a/src/Generators/TypeScriptDeclarations.ts
+++ b/src/Generators/TypeScriptDeclarations.ts
@@ -6,7 +6,7 @@ import { isFirstClassValue } from "../type-classifiers.js";
 import type { GeneratorInfo, GeneratorOptions } from "./Generator.js";
 import { Generator } from "./Generator.js";
 import type { JavaScriptModule } from "./JavaScript.js";
-import { quoteKey } from "./value-serializers.js";
+import { quoteKey, quoteString } from "./value-serializers.js";
 
 /**
  * Produce a TypeScript type annotation for a token value. Narrow by
@@ -32,7 +32,7 @@ const toTypeAnnotation = (value: unknown, loose: boolean): string => {
     return typeof value;
   }
   if (typeof value === "string") {
-    return JSON.stringify(value);
+    return quoteString(value);
   }
   if (typeof value === "number" || typeof value === "boolean") {
     return String(value);
@@ -146,7 +146,16 @@ export class TypeScriptDeclarations extends Generator<TypeScriptDeclarationsOpts
     if (this.options.groups) {
       const groupDecls = groups.map(({ groupName, entries }) => {
         const union = entries.map(({ shortName }) => `'${shortName}'`).join(" | ");
-        return `export declare const ${groupName}: (name: ${union}) => string;`;
+        // The accessor does a runtime lookup, so the return can't be narrowed
+        // to a specific value per name — widen to the primitive type(s)
+        // (`string`, `number`, or a union for a mixed group) rather than emit a
+        // large, non-narrowing literal union. Precise literals stay available
+        // on the `tokens` object for static access. `toTypeAnnotation(_, true)`
+        // forces the widened form regardless of the generator's `loose` option.
+        const returnType = [
+          ...new Set(entries.map(({ token }) => toTypeAnnotation(token.value, true))),
+        ].join(" | ");
+        return `export declare const ${groupName}: (name: ${union}) => ${returnType};`;
       });
       parts.push("", ...groupDecls);
     }

--- a/src/Generators/TypeScriptDeclarations.vitest.snap
+++ b/src/Generators/TypeScriptDeclarations.vitest.snap
@@ -17,17 +17,17 @@ export declare const tokens: {
    *  Use for body fonts
    *  Type: font-family
    */
-  readonly body: "\\"Roboto Condensed\\", Arial, sans";
+  readonly body: '"Roboto Condensed", Arial, sans';
   /**
    *  the primary branding color
    *  Type: color
    */
-  readonly primary: "aliceblue";
+  readonly primary: 'aliceblue';
   /**
    *  the secondary branding color
    *  Type: color
    */
-  readonly secondary: "rgb(102, 205, 170)";
+  readonly secondary: 'rgb(102, 205, 170)';
 };
 
 export type TokenNames = {
@@ -55,15 +55,15 @@ export declare const tokens: {
   /**
    *  Type: color
    */
-  readonly colorPrimary: "aliceblue";
+  readonly colorPrimary: 'aliceblue';
   /**
    *  Type: color
    */
-  readonly colorSecondary: "rgb(102, 205, 170)";
+  readonly colorSecondary: 'rgb(102, 205, 170)';
   /**
    *  Type: spacing
    */
-  readonly spacingSm: "4px";
+  readonly spacingSm: '4px';
 };
 
 export type TokenNames = {

--- a/src/Generators/__snapshots__/JavaScript.test.ts.snap
+++ b/src/Generators/__snapshots__/JavaScript.test.ts.snap
@@ -56,14 +56,18 @@ const _color = {
   secondary: tokens.colorSecondary,
 };
 export const color = (name) => {
-  if (!(name in _color)) throw new Error(\`Unknown color token: \${name}\`);
+  if (!Object.prototype.hasOwnProperty.call(_color, name)) {
+    throw new Error(\`Unknown color token: \${name}\`);
+  }
   return _color[name];
 };
 const _spacing = {
   sm: tokens.spacingSm,
 };
 export const spacing = (name) => {
-  if (!(name in _spacing)) throw new Error(\`Unknown spacing token: \${name}\`);
+  if (!Object.prototype.hasOwnProperty.call(_spacing, name)) {
+    throw new Error(\`Unknown spacing token: \${name}\`);
+  }
   return _spacing[name];
 };
 

--- a/src/Generators/__snapshots__/TypeScript.test.ts.snap
+++ b/src/Generators/__snapshots__/TypeScript.test.ts.snap
@@ -17,15 +17,15 @@ export declare const tokens: {
   /**
    *  Type: color
    */
-  readonly primary: "#0066cc";
+  readonly primary: '#0066cc';
   /**
    *  Type: color
    */
-  readonly accent: "#ff6600";
+  readonly accent: '#ff6600';
   /**
    *  Type: spacing
    */
-  readonly sm: "0.5rem";
+  readonly sm: '0.5rem';
 };
 
 export type TokenNames = {
@@ -66,14 +66,18 @@ const _color = {
   accent: tokens.accent,
 };
 export const color = (name) => {
-  if (!(name in _color)) throw new Error(\`Unknown color token: \${name}\`);
+  if (!Object.prototype.hasOwnProperty.call(_color, name)) {
+    throw new Error(\`Unknown color token: \${name}\`);
+  }
   return _color[name];
 };
 const _spacing = {
   sm: tokens.sm,
 };
 export const spacing = (name) => {
-  if (!(name in _spacing)) throw new Error(\`Unknown spacing token: \${name}\`);
+  if (!Object.prototype.hasOwnProperty.call(_spacing, name)) {
+    throw new Error(\`Unknown spacing token: \${name}\`);
+  }
   return _spacing[name];
 };
 

--- a/src/Generators/__snapshots__/TypeScriptDeclarations.test.ts.snap
+++ b/src/Generators/__snapshots__/TypeScriptDeclarations.test.ts.snap
@@ -17,17 +17,17 @@ export declare const tokens: {
    *  Use for body fonts
    *  Type: font-family
    */
-  readonly body: "\\"Roboto Condensed\\", Arial, sans";
+  readonly body: '"Roboto Condensed", Arial, sans';
   /**
    *  the primary branding color
    *  Type: color
    */
-  readonly primary: "aliceblue";
+  readonly primary: 'aliceblue';
   /**
    *  the secondary branding color
    *  Type: color
    */
-  readonly secondary: "rgb(102, 205, 170)";
+  readonly secondary: 'rgb(102, 205, 170)';
 };
 
 export type TokenNames = {
@@ -55,15 +55,15 @@ export declare const tokens: {
   /**
    *  Type: color
    */
-  readonly colorPrimary: "aliceblue";
+  readonly colorPrimary: 'aliceblue';
   /**
    *  Type: color
    */
-  readonly colorSecondary: "rgb(102, 205, 170)";
+  readonly colorSecondary: 'rgb(102, 205, 170)';
   /**
    *  Type: spacing
    */
-  readonly spacingSm: "4px";
+  readonly spacingSm: '4px';
 };
 
 export type TokenNames = {

--- a/src/Generators/value-serializers.ts
+++ b/src/Generators/value-serializers.ts
@@ -73,18 +73,23 @@ export const cssMapValue = (value: unknown): string => {
 // contain literal line terminators.
 const JS_LINE_SEPARATORS = new RegExp(`[${String.fromCharCode(0x2028, 0x2029)}]`, "g");
 
+// Single-quote a string for emission into generated source. Using single
+// quotes means values containing double quotes (e.g. font stacks like
+// `"Times New Roman"`) don't need escaping. JSON.stringify covers \n, \r, \t,
+// NUL, and other control chars; we then strip its double-quote wrapper,
+// unescape \", hand-escape U+2028 / U+2029, and escape single quotes.
+export const quoteString = (val: string): string => {
+  const escaped = JSON.stringify(val)
+    .slice(1, -1)
+    .replace(/\\"/g, '"')
+    .replace(JS_LINE_SEPARATORS, (c) => `\\u${c.charCodeAt(0).toString(16).padStart(4, "0")}`)
+    .replace(/'/g, "\\'");
+  return `'${escaped}'`;
+};
+
 export const maybeQuote = (val: unknown): string => {
   if (typeof val === "string") {
-    // JSON.stringify covers \n, \r, \t, NUL, and other control chars.
-    // Strip the surrounding double-quote, unescape \" (our wrapper is
-    // single-quoted so double quotes don't need escaping), hand-escape
-    // U+2028 / U+2029, and escape single quotes.
-    const escaped = JSON.stringify(val)
-      .slice(1, -1)
-      .replace(/\\"/g, '"')
-      .replace(JS_LINE_SEPARATORS, (c) => `\\u${c.charCodeAt(0).toString(16).padStart(4, "0")}`)
-      .replace(/'/g, "\\'");
-    return `'${escaped}'`;
+    return quoteString(val);
   }
   if (typeof val === "object" && val !== null) {
     return JSON.stringify(val);

--- a/src/output-validation.test.ts
+++ b/src/output-validation.test.ts
@@ -584,8 +584,8 @@ describe("output-validation: TypeScriptDeclarations (narrow default)", () => {
   });
 
   test("literal string types instead of widened string", () => {
-    // Narrow default emits `"1rem"`, not `string`, for dimension values
-    expect(ts).toContain('"1rem"');
+    // Narrow default emits `'1rem'`, not `string`, for dimension values
+    expect(ts).toContain("'1rem'");
   });
 
   test("mode type should be Partial<...>", () => {


### PR DESCRIPTION
Three cleanups to what the JavaScript and TypeScript(Declarations) generators emit. No API changes — existing token sets generate the same files apart from these.

### Braces + `hasOwnProperty` in group accessors

The `groups: true` accessors were emitted as a braceless one-liner:

```js
export const fontFamily = (name) => {
  if (!(name in _fontFamily)) throw new Error(`Unknown fontFamily token: ${name}`);
  return _fontFamily[name];
};
```

Now braced (consistent with the rest of the codebase, and lint-clean) and using `Object.prototype.hasOwnProperty.call(...)` instead of `name in`:

```js
export const fontFamily = (name) => {
  if (!Object.prototype.hasOwnProperty.call(_fontFamily, name)) {
    throw new Error(`Unknown fontFamily token: ${name}`);
  }
  return _fontFamily[name];
};
```

`name in` walks the prototype chain, so `fontFamily("toString")` passed the guard and returned an inherited function instead of throwing. Spelled out rather than `Object.hasOwn` because the output runs in the consumer's environment, which may predate ES2022.

### Accessor return types reflect the value type

The `.d.ts` accessors were all typed `=> string`, including numeric groups like `z-index` and `font-weight`. They now return the actual primitive — `number`, `string`, or a union for a mixed group. Widened rather than a literal union, because the accessor does a runtime lookup and can't be narrowed per name; the precise literals stay on the `tokens` object for static access.

### Single-quoted string literals

Font stacks with embedded double quotes came out escaped:

```ts
readonly fontFamilySerif: "Signifier, ui-serif, \"Times New Roman\", serif";
```

Single quotes avoid the escaping:

```ts
readonly fontFamilySerif: 'Signifier, ui-serif, "Times New Roman", serif';
```

The runtime `.mjs` already single-quoted its values; this makes the `.d.ts` match. The logic is shared via a `quoteString` helper extracted from `maybeQuote`. `'x'` and `"x"` are identical as TypeScript literal types, so nothing changes type-level.

### Testing

Full suite green on Bun and Node, lint and format clean. Added a test for numeric accessor return types; snapshots updated.
