### PR TITLE
Bump version to 2.0.0-beta.5

### DIFF
--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@shawnrice/teikn",
-  "version": "2.0.0-beta.4",
+  "version": "2.0.0-beta.5",
   "exports": {
     ".": "./index.ts",
     "./builders": "./src/builders.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teikn",
-  "version": "2.0.0-beta.4",
+  "version": "2.0.0-beta.5",
   "description": "Generate design tokens",
   "keywords": [
     "design",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '2.0.0-beta.4';
+export const version = '2.0.0-beta.5';


### PR DESCRIPTION
Release `2.0.0-beta.5`. Bumps the three version locations (`package.json`, `jsr.json`, `src/version.ts`); changelog section already landed in #41.

Covers everything merged since beta.4: Typography & Border value types + per-field refs and the `CssVars` cascade-layer option (#41), plus dep updates / tooling (#42, no user-facing change).

After merge, tag `v2.0.0-beta.5` on `main` to trigger publishing.