### PR TITLE
Add Oklab and Oklch color spaces with gamut mapping and a standalone color export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 2.0.0-beta.6
+
+### Added
+
+- **Oklab and Oklch color spaces.** `Color` now speaks Björn Ottosson's perceptual space and its
+  authoring-friendly polar form as first-class spaces, alongside RGB/HSL/XYZ/LAB/LCH. Construct with
+  `Color.fromOklab(L, a, b)` / `Color.fromOklch(L, C, h)` (or tuples), read with `asOklab(A)` /
+  `asOklch(A)`, and parse/serialize CSS syntax — `oklab(L a b)` and `oklch(L C h)`, with `%`
+  lightness, `/ alpha`, and space or comma separators all accepted. Conversion runs through linear
+  sRGB (not XYZ). New operation namespaces mirror the existing ones: `color.oklab` exposes
+  `lightness`/`a`/`b`, the CSS-accurate linear `mix`, and `lighten`/`darken`; `color.oklch` exposes
+  `lightness`/`chroma`/`hue`, `rotateHue`, `lighten`/`darken`, `saturate`/`desaturate`, and
+  `complement` — holding L constant while rotating hue makes even-lightness palettes pleasant to
+  generate.
+- **Gamut mapping on sRGB emit.** When an Oklab/Oklch color falls outside the sRGB gamut, converting
+  it back to `rgb`/`hex` no longer clips per channel. It applies CSS Color 4 gamut mapping — holding
+  L and h while binary-searching a reduced chroma, with a clip + Oklab ΔE (JND ≈ 0.02) fallback — so
+  saturated out-of-gamut inputs land on a faithful displayable color instead of an over-saturated,
+  lightness-distorted one. In-gamut colors are unaffected.
+- **`teikn/color` subpath export.** `import { Color } from "teikn/color"` pulls in just the color
+  toolkit, with an import graph that reaches no generators and no `node:*` builtins — so it
+  tree-shakes clean and bundles for the browser without Node shims. (The main `teikn` barrel still
+  transitively imports `node:os`/`node:fs` via the generators.)
+
 ## 2.0.0-beta.5
 
 ### Added

--- a/jsr.json
+++ b/jsr.json
@@ -3,6 +3,7 @@
   "version": "2.0.0-beta.5",
   "exports": {
     ".": "./index.ts",
+    "./color": "./src/TokenTypes/Color/index.ts",
     "./builders": "./src/builders.ts",
     "./generators": "./src/Generators/index.ts",
     "./storybook": "./src/storybook/index.ts"

--- a/package.json
+++ b/package.json
@@ -34,6 +34,10 @@
       "import": "./lib/index.js",
       "require": "./lib/index.js"
     },
+    "./color": {
+      "types": "./lib/src/TokenTypes/Color/index.d.ts",
+      "import": "./lib/src/TokenTypes/Color/index.js"
+    },
     "./builders": {
       "import": "./lib/src/builders.js",
       "types": "./lib/src/builders.d.ts"

--- a/src/TokenTypes/Color/Color.ts
+++ b/src/TokenTypes/Color/Color.ts
@@ -7,6 +7,8 @@ import { namedColorsByValue } from './namedColors.js';
 import { HSLOperations } from './operations/HSLOperations.js';
 import { LABOperations } from './operations/LABOperations.js';
 import { LCHOperations } from './operations/LCHOperations.js';
+import { OklabOperations } from './operations/OklabOperations.js';
+import { OklchOperations } from './operations/OklchOperations.js';
 import { RGBOperations } from './operations/RGBOperations.js';
 import { XYZOperations } from './operations/XYZOperations.js';
 import { parseColorString } from './parseColorString.js';
@@ -19,6 +21,10 @@ import type {
   LABA,
   LCH,
   LCHA,
+  Oklab,
+  OklabA,
+  Oklch,
+  OklchA,
   RGB,
   RGBA,
   XYZ,
@@ -36,6 +42,10 @@ export type InternalCreate = (space: Space, data: SpaceData[Space], alpha: numbe
 const PRECISION_ALPHA = 4;
 const PRECISION_LAB = 2;
 const PRECISION_XYZ = 5;
+// Oklab/Oklch L, a, b, C sit in tiny ranges (~0..1 / ~-0.4..0.4) so they need
+// more decimals; hue is in degrees and needs fewer.
+const PRECISION_OKLAB = 5;
+const PRECISION_OK_HUE = 3;
 
 // String formatters — each handles both opaque and alpha variants
 const fmtTriplet = (
@@ -47,6 +57,22 @@ const fmtTriplet = (
   alpha?: number,
 ): string => {
   const core = `${round(precision, a)}, ${round(precision, b)}, ${round(precision, c)}`;
+
+  return alpha !== undefined
+    ? `${name}(${core} / ${round(PRECISION_ALPHA, alpha)})`
+    : `${name}(${core})`;
+};
+
+// Modern CSS oklab()/oklch() use space-separated components (never commas).
+const fmtOkTriplet = (
+  name: string,
+  a: number,
+  b: number,
+  c: number,
+  cPrecision: number,
+  alpha?: number,
+): string => {
+  const core = `${round(PRECISION_OKLAB, a)} ${round(PRECISION_OKLAB, b)} ${round(cPrecision, c)}`;
 
   return alpha !== undefined
     ? `${name}(${core} / ${round(PRECISION_ALPHA, alpha)})`
@@ -91,6 +117,20 @@ const fmt = {
       ? fmtTriplet('xyz', PRECISION_XYZ, x, y, z, values[3])
       : fmtTriplet('xyz', PRECISION_XYZ, x, y, z);
   },
+  oklab: (values: Oklab | OklabA): string => {
+    const [L, a, b] = values;
+
+    return values.length === 4
+      ? fmtOkTriplet('oklab', L, a, b, PRECISION_OKLAB, values[3])
+      : fmtOkTriplet('oklab', L, a, b, PRECISION_OKLAB);
+  },
+  oklch: (values: Oklch | OklchA): string => {
+    const [L, c, h] = values;
+
+    return values.length === 4
+      ? fmtOkTriplet('oklch', L, c, h, PRECISION_OK_HUE, values[3])
+      : fmtOkTriplet('oklch', L, c, h, PRECISION_OK_HUE);
+  },
 };
 
 // sRGB linearization / delinearization helpers
@@ -127,6 +167,8 @@ export class Color {
   #lab?: LABOperations;
   #lch?: LCHOperations;
   #xyz?: XYZOperations;
+  #oklab?: OklabOperations;
+  #oklch?: OklchOperations;
 
   /**
    * Create a color from a string (hex, rgb, hsl, lab, lch, xyz, named color) or Color
@@ -317,6 +359,18 @@ export class Color {
     return Color.#fromSpace('xyz', first, second, third, alpha);
   }
 
+  static fromOklab(l: number, a: number, b: number, alpha?: number): Color;
+  static fromOklab(oklab: Oklab, alpha?: number): Color;
+  static fromOklab(first: number | Oklab, second?: number, third?: number, alpha?: number): Color {
+    return Color.#fromSpace('oklab', first, second, third, alpha);
+  }
+
+  static fromOklch(l: number, c: number, h: number, a?: number): Color;
+  static fromOklch(oklch: Oklch, a?: number): Color;
+  static fromOklch(first: number | Oklch, second?: number, third?: number, alpha?: number): Color {
+    return Color.#fromSpace('oklch', first, second, third, alpha);
+  }
+
   // ─── Space-scoped sub-APIs ─────────────────────────────────
 
   /** RGB-space operations (red, green, blue, mix, invert) */
@@ -362,6 +416,24 @@ export class Color {
     }
 
     return this.#xyz;
+  }
+
+  /** Oklab-space operations (lightness, a, b, mix, lighten, darken) */
+  get oklab(): OklabOperations {
+    if (!this.#oklab) {
+      this.#oklab = new OklabOperations(this, this.#boundCreateInternal);
+    }
+
+    return this.#oklab;
+  }
+
+  /** Oklch-space operations (lightness, chroma, hue, rotateHue, lighten, darken) */
+  get oklch(): OklchOperations {
+    if (!this.#oklch) {
+      this.#oklch = new OklchOperations(this, this.#boundCreateInternal);
+    }
+
+    return this.#oklch;
   }
 
   // ─── RGB mutation methods (backward-compatible) ────────────
@@ -764,6 +836,26 @@ export class Color {
     return [...this.asLCH(), this.#alpha] as unknown as LCHA;
   }
 
+  /** Get the color as an Oklab tuple */
+  asOklab(): Oklab {
+    return this.#resolve('oklab');
+  }
+
+  /** Get the color as an Oklab tuple with alpha */
+  asOklabA(): OklabA {
+    return [...this.asOklab(), this.#alpha] as unknown as OklabA;
+  }
+
+  /** Get the color as an Oklch tuple */
+  asOklch(): Oklch {
+    return this.#resolve('oklch');
+  }
+
+  /** Get the color as an Oklch tuple with alpha */
+  asOklchA(): OklchA {
+    return [...this.asOklch(), this.#alpha] as unknown as OklchA;
+  }
+
   /** Get the color as a 3-digit hex string (if possible) */
   asHex3(): string {
     return `#${RGBToHex(this.asRGB(), true)}`;
@@ -825,6 +917,14 @@ export class Color {
         return fmt.lch(this.asLCH());
       case 'lcha':
         return fmt.lch(this.asLCHA());
+      case 'oklab':
+        return fmt.oklab(this.asOklab());
+      case 'oklaba':
+        return fmt.oklab(this.asOklabA());
+      case 'oklch':
+        return fmt.oklch(this.asOklch());
+      case 'oklcha':
+        return fmt.oklch(this.asOklchA());
       case 'xyz':
         return fmt.xyz(this.asXYZ());
       case 'xyza':

--- a/src/TokenTypes/Color/ColorSpace.ts
+++ b/src/TokenTypes/Color/ColorSpace.ts
@@ -3,16 +3,28 @@ import {
   LABToLCH,
   LABToXYZ,
   LCHToLAB,
+  OklabToOklch,
+  OklabToRGB,
+  OklchToOklab,
   RGBToHSL,
+  RGBToOklab,
   RGBToXYZ,
   XYZToLAB,
   XYZToRGB,
 } from './conversions.js';
-import type { HSL, LAB, LCH, RGB, XYZ } from './types.js';
+import type { HSL, LAB, LCH, Oklab, Oklch, RGB, XYZ } from './types.js';
 
-export type Space = 'rgb' | 'hsl' | 'xyz' | 'lab' | 'lch';
+export type Space = 'rgb' | 'hsl' | 'xyz' | 'lab' | 'lch' | 'oklab' | 'oklch';
 
-export type SpaceData = { hsl: HSL; lab: LAB; lch: LCH; rgb: RGB; xyz: XYZ };
+export type SpaceData = {
+  hsl: HSL;
+  lab: LAB;
+  lch: LCH;
+  oklab: Oklab;
+  oklch: Oklch;
+  rgb: RGB;
+  xyz: XYZ;
+};
 
 type DirectConversion = {
   [From in Space]?: {
@@ -24,31 +36,80 @@ const direct: DirectConversion = {
   hsl: { rgb: HSLToRGB },
   lab: { xyz: LABToXYZ, lch: LABToLCH },
   lch: { lab: LCHToLAB },
-  rgb: { hsl: RGBToHSL, xyz: RGBToXYZ },
+  oklab: { rgb: OklabToRGB, oklch: OklabToOklch },
+  oklch: { oklab: OklchToOklab },
+  rgb: { hsl: RGBToHSL, xyz: RGBToXYZ, oklab: RGBToOklab },
   xyz: { rgb: XYZToRGB, lab: XYZToLAB },
 };
 
 // Hardcoded shortest paths through the conversion graph:
-// HSL ↔ RGB ↔ XYZ ↔ LAB ↔ LCH
+//   HSL ↔ RGB ↔ XYZ ↔ LAB ↔ LCH
+//             ↕
+//           Oklab ↔ Oklch
 const paths: Record<Space, Record<Space, Space[]>> = {
   hsl: {
     hsl: [],
     lab: ['rgb', 'xyz', 'lab'],
     lch: ['rgb', 'xyz', 'lab', 'lch'],
+    oklab: ['rgb', 'oklab'],
+    oklch: ['rgb', 'oklab', 'oklch'],
     rgb: ['rgb'],
     xyz: ['rgb', 'xyz'],
   },
-  lab: { hsl: ['xyz', 'rgb', 'hsl'], lab: [], lch: ['lch'], rgb: ['xyz', 'rgb'], xyz: ['xyz'] },
+  lab: {
+    hsl: ['xyz', 'rgb', 'hsl'],
+    lab: [],
+    lch: ['lch'],
+    oklab: ['xyz', 'rgb', 'oklab'],
+    oklch: ['xyz', 'rgb', 'oklab', 'oklch'],
+    rgb: ['xyz', 'rgb'],
+    xyz: ['xyz'],
+  },
   lch: {
     hsl: ['lab', 'xyz', 'rgb', 'hsl'],
     lab: ['lab'],
     lch: [],
+    oklab: ['lab', 'xyz', 'rgb', 'oklab'],
+    oklch: ['lab', 'xyz', 'rgb', 'oklab', 'oklch'],
     rgb: ['lab', 'xyz', 'rgb'],
     xyz: ['lab', 'xyz'],
   },
-  rgb: { hsl: ['hsl'], lab: ['xyz', 'lab'], lch: ['xyz', 'lab', 'lch'], rgb: [], xyz: ['xyz'] },
-
-  xyz: { hsl: ['rgb', 'hsl'], lab: ['lab'], lch: ['lab', 'lch'], rgb: ['rgb'], xyz: [] },
+  oklab: {
+    hsl: ['rgb', 'hsl'],
+    lab: ['rgb', 'xyz', 'lab'],
+    lch: ['rgb', 'xyz', 'lab', 'lch'],
+    oklab: [],
+    oklch: ['oklch'],
+    rgb: ['rgb'],
+    xyz: ['rgb', 'xyz'],
+  },
+  oklch: {
+    hsl: ['oklab', 'rgb', 'hsl'],
+    lab: ['oklab', 'rgb', 'xyz', 'lab'],
+    lch: ['oklab', 'rgb', 'xyz', 'lab', 'lch'],
+    oklab: ['oklab'],
+    oklch: [],
+    rgb: ['oklab', 'rgb'],
+    xyz: ['oklab', 'rgb', 'xyz'],
+  },
+  rgb: {
+    hsl: ['hsl'],
+    lab: ['xyz', 'lab'],
+    lch: ['xyz', 'lab', 'lch'],
+    oklab: ['oklab'],
+    oklch: ['oklab', 'oklch'],
+    rgb: [],
+    xyz: ['xyz'],
+  },
+  xyz: {
+    hsl: ['rgb', 'hsl'],
+    lab: ['lab'],
+    lch: ['lab', 'lch'],
+    oklab: ['rgb', 'oklab'],
+    oklch: ['rgb', 'oklab', 'oklch'],
+    rgb: ['rgb'],
+    xyz: [],
+  },
 };
 
 type Conversion = (d: SpaceData[Space]) => SpaceData[Space];

--- a/src/TokenTypes/Color/conversions.ts
+++ b/src/TokenTypes/Color/conversions.ts
@@ -1,5 +1,5 @@
-import type { HSL, LAB, LCH, RGB, XYZ } from './types.js';
-import { byteToUnit, pad0, parseInt16, pipe } from './util.js';
+import type { HSL, LAB, LCH, Oklab, Oklch, RGB, XYZ } from './types.js';
+import { byteToUnit, clamp, pad0, parseInt16, pipe } from './util.js';
 
 // Color space conversion references:
 // - W3C CSS Color 4 conversions: https://github.com/w3c/csswg-drafts/blob/main/css-color-4/conversions.js
@@ -179,6 +179,152 @@ export const LCHToLAB = ([l, c, h]: LCH): LAB => {
   const b = c * Math.sin(hRad);
 
   return [l, a, b];
+};
+
+// ─── linear sRGB ↔ Oklab ↔ Oklch ────────────────────────────
+//
+// Oklab (Björn Ottosson, 2020) is a perceptual color space; Oklch is its
+// polar form. Conversion goes through *linear* sRGB — NOT XYZ — using the
+// matrices published at https://bottosson.github.io/posts/oklab/.
+//
+// The graph edge that surfaces Oklab/Oklch to sRGB is `oklab → rgb`, and the
+// only conversion paths that traverse it originate at oklab/oklch. That makes
+// `OklabToRGB` the natural (and sufficient) place to gamut-map: an Oklch color
+// outside sRGB is mapped back via CSS Color 4 chroma reduction instead of a
+// naive per-channel clip.
+
+const clamp01 = (v: number): number => clamp(0, 1, v);
+
+/** Oklab → linear-light sRGB (channels may fall outside [0, 1] when out of gamut) */
+const oklabToLinearSRGB = ([L, a, b]: Oklab): [number, number, number] => {
+  const l_ = L + 0.3963377774 * a + 0.2158037573 * b;
+  const m_ = L - 0.1055613458 * a - 0.0638541728 * b;
+  const s_ = L - 0.0894841775 * a - 1.291485548 * b;
+
+  const l = l_ * l_ * l_;
+  const m = m_ * m_ * m_;
+  const s = s_ * s_ * s_;
+
+  return [
+    4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s,
+    -1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s,
+    -0.0041960863 * l - 0.7034186147 * m + 1.707614701 * s,
+  ];
+};
+
+/** linear-light sRGB → Oklab */
+const linearSRGBToOklab = ([r, g, b]: readonly [number, number, number]): Oklab => {
+  const l = Math.cbrt(0.4122214708 * r + 0.5363325363 * g + 0.0514459929 * b);
+  const m = Math.cbrt(0.2119034982 * r + 0.6806995451 * g + 0.1073969566 * b);
+  const s = Math.cbrt(0.0883024619 * r + 0.2817188376 * g + 0.6299787005 * b);
+
+  return [
+    0.2104542553 * l + 0.793617785 * m - 0.0040720468 * s,
+    1.9779984951 * l - 2.428592205 * m + 0.4505937099 * s,
+    0.0259040371 * l + 0.7827717662 * m - 0.808675766 * s,
+  ];
+};
+
+export const OklabToOklch = ([L, a, b]: Oklab): Oklch => {
+  const C = Math.hypot(a, b);
+  // Below this chroma the hue is meaningless (achromatic) — pin it to 0.
+  const h = C < 1e-4 ? 0 : (((Math.atan2(b, a) * DEG) % 360) + 360) % 360;
+
+  return [L, C, h];
+};
+
+export const OklchToOklab = ([L, C, h]: Oklch): Oklab => {
+  const hRad = h * RAD;
+
+  return [L, C * Math.cos(hRad), C * Math.sin(hRad)];
+};
+
+export const RGBToOklab = (rgb: RGB): Oklab =>
+  linearSRGBToOklab(rgb.map(byteToUnit).map(linearize) as [number, number, number]);
+
+const linInGamut = ([r, g, b]: readonly [number, number, number]): boolean =>
+  r >= -1e-4 && r <= 1 + 1e-4 && g >= -1e-4 && g <= 1 + 1e-4 && b >= -1e-4 && b <= 1 + 1e-4;
+
+/** Gamma-encode a linear-light sRGB triplet, clip to [0, 1], scale to 0-255 bytes */
+const linearSRGBToByte = (lin: readonly [number, number, number]): RGB =>
+  lin.map(applyGamma).map(v => Math.round(clamp01(v) * 255)) as unknown as RGB;
+
+/** Euclidean ΔE in Oklab (the perceptual distance CSS Color 4 uses for gamut mapping) */
+const deltaEOK = (a: Oklab, b: Oklab): number => Math.hypot(a[0] - b[0], a[1] - b[1], a[2] - b[2]);
+
+/**
+ * Oklab → sRGB bytes with CSS Color 4 gamut mapping.
+ *
+ * If the color is already displayable it is converted directly. Otherwise we
+ * hold L and h and binary-search a reduced chroma, using clip + Oklab ΔE
+ * (JND ≈ 0.02) as the acceptance test — never a naive per-channel clip of the
+ * full-chroma color.
+ * @see https://www.w3.org/TR/css-color-4/#css-gamut-mapping
+ */
+export const OklabToRGB = (oklab: Oklab): RGB => {
+  const direct = oklabToLinearSRGB(oklab);
+
+  if (linInGamut(direct)) {
+    return linearSRGBToByte(direct);
+  }
+
+  const [L, C, h] = OklabToOklch(oklab);
+
+  // Degenerate lightness: no chroma can pull these into gamut.
+  if (L >= 1) {
+    return [255, 255, 255];
+  }
+
+  if (L <= 0) {
+    return [0, 0, 0];
+  }
+
+  const JND = 0.02;
+  const EPSILON = 1e-4;
+
+  const linAt = (chroma: number): [number, number, number] =>
+    oklabToLinearSRGB(OklchToOklab([L, chroma, h]));
+
+  let current = linAt(C);
+  let clipped: [number, number, number] = [
+    clamp01(current[0]),
+    clamp01(current[1]),
+    clamp01(current[2]),
+  ];
+
+  if (deltaEOK(linearSRGBToOklab(clipped), linearSRGBToOklab(current)) < JND) {
+    return linearSRGBToByte(clipped);
+  }
+
+  let min = 0;
+  let max = C;
+  let minInGamut = true;
+
+  while (max - min > EPSILON) {
+    const chroma = (min + max) / 2;
+    current = linAt(chroma);
+
+    if (minInGamut && linInGamut(current)) {
+      min = chroma;
+      continue;
+    }
+
+    clipped = [clamp01(current[0]), clamp01(current[1]), clamp01(current[2])];
+    const E = deltaEOK(linearSRGBToOklab(clipped), linearSRGBToOklab(current));
+
+    if (E < JND) {
+      if (JND - E < EPSILON) {
+        return linearSRGBToByte(clipped);
+      }
+
+      minInGamut = false;
+      min = chroma;
+    } else {
+      max = chroma;
+    }
+  }
+
+  return linearSRGBToByte([clamp01(current[0]), clamp01(current[1]), clamp01(current[2])]);
 };
 
 // ─── Hex ─────────────────────────────────────────────────────

--- a/src/TokenTypes/Color/oklab.test.ts
+++ b/src/TokenTypes/Color/oklab.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, test } from 'bun:test';
+
+import { Color } from './Color.js';
+import { OklabToOklch, OklabToRGB, OklchToOklab, RGBToOklab } from './conversions.js';
+
+// Reference values were checked against culori (@culori/core) — the de-facto
+// reference JS implementation of Oklab/Oklch — to 4 decimal places.
+
+describe('Oklab / Oklch conversions', () => {
+  test('sRGB red matches the reference Oklab value', () => {
+    const [L, a, b] = new Color('#ff0000').asOklab();
+    expect(L).toBeCloseTo(0.627955, 5);
+    expect(a).toBeCloseTo(0.224863, 5);
+    expect(b).toBeCloseTo(0.125846, 5);
+  });
+
+  test('sRGB red matches the reference Oklch value', () => {
+    const [L, C, h] = new Color('#ff0000').asOklch();
+    expect(L).toBeCloseTo(0.627955, 5);
+    expect(C).toBeCloseTo(0.257683, 5);
+    expect(h).toBeCloseTo(29.234, 3);
+  });
+
+  test('sRGB green matches the reference Oklab value', () => {
+    const [L, a, b] = new Color('#00ff00').asOklab();
+    expect(L).toBeCloseTo(0.8664, 4);
+    expect(a).toBeCloseTo(-0.2339, 4);
+    expect(b).toBeCloseTo(0.1795, 4);
+  });
+
+  test('sRGB blue matches the reference Oklch value', () => {
+    const [L, C, h] = new Color('#0000ff').asOklch();
+    expect(L).toBeCloseTo(0.452, 3);
+    expect(C).toBeCloseTo(0.3132, 4);
+    expect(h).toBeCloseTo(264.052, 3);
+  });
+
+  test('white is L=1 with no chroma', () => {
+    const [L, a, b] = new Color('#ffffff').asOklab();
+    expect(L).toBeCloseTo(1, 4);
+    expect(a).toBeCloseTo(0, 4);
+    expect(b).toBeCloseTo(0, 4);
+  });
+
+  test('black is L=0 with no chroma', () => {
+    expect(new Color('#000000').asOklab()).toEqual([0, 0, 0]);
+  });
+
+  test('achromatic colors report hue 0 in Oklch', () => {
+    expect(new Color('#808080').asOklch()[2]).toBe(0);
+  });
+});
+
+describe('Oklab / Oklch round-trips', () => {
+  const hexes = [
+    '#ff0000',
+    '#00ff00',
+    '#0000ff',
+    '#1a2b3c',
+    '#7f7f7f',
+    '#123456',
+    '#abcdef',
+    '#010203',
+  ];
+
+  test.each(hexes)('hex -> oklab -> hex is exact for %s', hex => {
+    expect(Color.fromOklab(new Color(hex).asOklab()).hex).toBe(hex);
+  });
+
+  test.each(hexes)('hex -> oklch -> hex is exact for %s', hex => {
+    expect(Color.fromOklch(new Color(hex).asOklch()).hex).toBe(hex);
+  });
+
+  test('oklab <-> oklch is symmetric', () => {
+    const oklab: [number, number, number] = [0.5325, -0.0225, -0.1663];
+    const back = OklchToOklab(OklabToOklch(oklab));
+    expect(back[0]).toBeCloseTo(oklab[0], 10);
+    expect(back[1]).toBeCloseTo(oklab[1], 10);
+    expect(back[2]).toBeCloseTo(oklab[2], 10);
+  });
+
+  test('RGBToOklab and OklabToRGB are inverse for in-gamut colors', () => {
+    expect(OklabToRGB(RGBToOklab([55, 192, 122]))).toEqual([55, 192, 122]);
+  });
+});
+
+describe('Oklab / Oklch string parsing & serialization', () => {
+  test('parses oklab() with space separators', () => {
+    const c = new Color('oklab(0.62795 0.22486 0.12585)');
+    expect(c.asOklab()[0]).toBeCloseTo(0.62795, 5);
+    expect(c.asOklab()[1]).toBeCloseTo(0.22486, 5);
+    expect(c.asOklab()[2]).toBeCloseTo(0.12585, 5);
+  });
+
+  test('parses oklch() with a percentage lightness', () => {
+    const c = new Color('oklch(62.8% 0.2577 29.23)');
+    expect(c.asOklch()[0]).toBeCloseTo(0.628, 3);
+    expect(c.asOklch()[1]).toBeCloseTo(0.2577, 4);
+    expect(c.asOklch()[2]).toBeCloseTo(29.23, 2);
+  });
+
+  test('parses an alpha component after a slash', () => {
+    const c = new Color('oklab(0.5 -0.1 0.1 / 0.5)');
+    expect(c.alpha).toBe(0.5);
+  });
+
+  test('serializes oklab() with CSS space syntax (no commas)', () => {
+    expect(new Color('#ff0000').toString('oklab')).toMatch(/^oklab\(0\.\d+ 0\.\d+ 0\.\d+\)$/);
+  });
+
+  test('serializes oklch() with alpha', () => {
+    expect(new Color('oklch(0.5 0.1 120 / 0.5)').toString('oklcha')).toBe(
+      'oklch(0.5 0.1 120 / 0.5)',
+    );
+  });
+
+  test('string round-trips through parse and serialize', () => {
+    const original = 'oklch(0.6279 0.2577 29.23)';
+    expect(new Color(original).toString('oklch')).toBe(original);
+  });
+});
+
+describe('Gamut mapping (CSS Color 4 chroma reduction)', () => {
+  const outOfGamut = ['oklch(0.7 0.4 30)', 'oklch(0.5 0.4 150)', 'oklch(0.85 0.4 250)'];
+
+  test.each(outOfGamut)('%s maps to a displayable sRGB color', spec => {
+    const [r, g, b] = new Color(spec).asRGB();
+
+    for (const channel of [r, g, b]) {
+      expect(Number.isInteger(channel)).toBe(true);
+      expect(channel).toBeGreaterThanOrEqual(0);
+      expect(channel).toBeLessThanOrEqual(255);
+    }
+  });
+
+  test('chroma reduction preserves lightness for out-of-gamut colors', () => {
+    // oklch(0.7 0.4 30) is far outside sRGB. Naive per-channel clipping distorts
+    // lightness; CSS chroma reduction holds L (and h) and only trims chroma, so
+    // the displayable result should keep its intended lightness closely.
+    const mapped = new Color('oklch(0.7 0.4 30)').asRGB();
+    const mappedColor = new Color(mapped[0], mapped[1], mapped[2]);
+    expect(mappedColor.asOklch()[0]).toBeCloseTo(0.7, 1);
+  });
+
+  test('a color on the sRGB gamut boundary round-trips exactly', () => {
+    // This Oklch value is exactly sRGB red — it must not be altered.
+    expect(new Color('oklch(0.62796 0.25768 29.234)').hex).toBe('#ff0000');
+  });
+
+  test('in-gamut Oklch colors are unaffected by gamut mapping', () => {
+    const spec = 'oklch(0.6 0.1 200)';
+    const c = new Color(spec);
+    // Round-trip through sRGB and back; lightness/hue should be preserved.
+    const back = new Color(c.hex).asOklch();
+    expect(back[0]).toBeCloseTo(0.6, 2);
+    expect(back[2]).toBeCloseTo(200, 0);
+  });
+});
+
+describe('Oklab operations namespace', () => {
+  test('lightness / a / b are readable and settable', () => {
+    const c = new Color('#3366cc');
+    expect(c.oklab.lightness()).toBeCloseTo(c.asOklab()[0], 10);
+    expect(c.oklab.a(0.1).asOklab()[1]).toBeCloseTo(0.1, 10);
+    expect(c.oklab.b(-0.1).asOklab()[2]).toBeCloseTo(-0.1, 10);
+  });
+
+  test('mix interpolates L, a, b linearly', () => {
+    const red = new Color('#ff0000');
+    const blue = new Color('#0000ff');
+    const mid = red.oklab.mix(blue, 0.5).asOklab();
+    const expected = red.asOklab().map((v, i) => (v + blue.asOklab()[i]!) / 2);
+    expect(mid[0]).toBeCloseTo(expected[0]!, 10);
+    expect(mid[1]).toBeCloseTo(expected[1]!, 10);
+    expect(mid[2]).toBeCloseTo(expected[2]!, 10);
+  });
+
+  test('lighten increases lightness', () => {
+    const c = new Color('oklch(0.5 0.1 30)');
+    expect(c.oklab.lighten(0.2).asOklab()[0]).toBeGreaterThan(c.asOklab()[0]);
+  });
+});
+
+describe('Oklch operations namespace', () => {
+  test('rotateHue holds lightness and chroma', () => {
+    const c = new Color('oklch(0.6 0.15 30)');
+    const rotated = c.oklch.rotateHue(120);
+    expect(rotated.asOklch()[0]).toBeCloseTo(0.6, 10);
+    expect(rotated.asOklch()[1]).toBeCloseTo(0.15, 10);
+    expect(rotated.asOklch()[2]).toBeCloseTo(150, 10);
+  });
+
+  test('rotateHue wraps around 360', () => {
+    expect(new Color('oklch(0.6 0.15 300)').oklch.rotateHue(120).asOklch()[2]).toBeCloseTo(60, 10);
+  });
+
+  test('lighten / darken adjust L', () => {
+    const c = new Color('oklch(0.5 0.1 30)');
+    expect(c.oklch.lighten(0.2).asOklch()[0]).toBeCloseTo(0.6, 10);
+    expect(c.oklch.darken(0.2).asOklch()[0]).toBeCloseTo(0.4, 10);
+  });
+
+  test('chroma is readable and settable', () => {
+    const c = new Color('oklch(0.6 0.15 30)');
+    expect(c.oklch.chroma()).toBeCloseTo(0.15, 10);
+    expect(c.oklch.chroma(0.05).asOklch()[1]).toBeCloseTo(0.05, 10);
+  });
+
+  test('even-lightness palette: rotating hue keeps L constant', () => {
+    const base = new Color('oklch(0.7 0.12 20)');
+    const palette = [0, 72, 144, 216, 288].map(deg => base.oklch.rotateHue(deg));
+
+    for (const swatch of palette) {
+      expect(swatch.asOklch()[0]).toBeCloseTo(0.7, 10);
+    }
+  });
+});
+
+describe('Oklab / Oklch factories & immutability', () => {
+  test('fromOklab accepts components and a tuple', () => {
+    const fromArgs = Color.fromOklab(0.6279, 0.2249, 0.1258);
+    const fromTuple = Color.fromOklab([0.6279, 0.2249, 0.1258]);
+    expect(fromArgs.hex).toBe(fromTuple.hex);
+  });
+
+  test('fromOklch carries alpha', () => {
+    expect(Color.fromOklch(0.6, 0.1, 120, 0.5).alpha).toBe(0.5);
+  });
+
+  test('asOklabA / asOklchA append alpha', () => {
+    const c = Color.fromOklab([0.5, 0.1, -0.1], 0.25);
+    expect(c.asOklabA()[3]).toBe(0.25);
+    expect(c.asOklchA()[3]).toBe(0.25);
+  });
+
+  test('operations return new immutable Color instances', () => {
+    const original = new Color('oklch(0.5 0.1 30)');
+    const lightened = original.oklch.lighten(0.2);
+    expect(original.toString('oklch')).toBe('oklch(0.5 0.1 30)');
+    expect(lightened).not.toBe(original);
+  });
+});

--- a/src/TokenTypes/Color/operations/OklabOperations.ts
+++ b/src/TokenTypes/Color/operations/OklabOperations.ts
@@ -1,0 +1,85 @@
+import type { Color, InternalCreate } from '../Color.js';
+import type { Oklab } from '../types.js';
+import { percentRange } from '../util.js';
+
+export class OklabOperations {
+  #color: Color;
+  #new: InternalCreate;
+
+  constructor(color: Color, createInternal: InternalCreate) {
+    this.#color = color;
+    this.#new = createInternal;
+  }
+
+  #oklab(): Oklab {
+    return this.#color.asOklab();
+  }
+
+  lightness(): number;
+  lightness(value: number): Color;
+  lightness(value?: number): number | Color {
+    if (value === undefined) {
+      return this.#oklab()[0];
+    }
+
+    const [, a, b] = this.#oklab();
+
+    return this.#new('oklab', [value, a, b], this.#color.alpha);
+  }
+
+  a(): number;
+  a(value: number): Color;
+  a(value?: number): number | Color {
+    if (value === undefined) {
+      return this.#oklab()[1];
+    }
+
+    const [L, , b] = this.#oklab();
+
+    return this.#new('oklab', [L, value, b], this.#color.alpha);
+  }
+
+  b(): number;
+  b(value: number): Color;
+  b(value?: number): number | Color {
+    if (value === undefined) {
+      return this.#oklab()[2];
+    }
+
+    const [L, a] = this.#oklab();
+
+    return this.#new('oklab', [L, a, value], this.#color.alpha);
+  }
+
+  /**
+   * Interpolate L, a, b linearly — the CSS-accurate Oklab lerp, and the most
+   * perceptually uniform mix available on a `Color`.
+   */
+  mix(other: Color, amount = 0.5): Color {
+    const amt = percentRange(amount);
+    const thisOklab = this.#oklab();
+    const otherOklab = other.asOklab();
+    const mixed: Oklab = [
+      thisOklab[0] * (1 - amt) + otherOklab[0] * amt,
+      thisOklab[1] * (1 - amt) + otherOklab[1] * amt,
+      thisOklab[2] * (1 - amt) + otherOklab[2] * amt,
+    ];
+    const alpha = this.#color.alpha * (1 - amt) + other.alpha * amt;
+
+    return this.#new('oklab', mixed, alpha);
+  }
+
+  lighten(amount: number): Color {
+    const [L, a, b] = this.#oklab();
+
+    return this.#new('oklab', [L + amount * L, a, b], this.#color.alpha);
+  }
+
+  darken(amount: number): Color {
+    return this.lighten(-amount);
+  }
+
+  toString(): string {
+    return this.#color.toString('oklab');
+  }
+}

--- a/src/TokenTypes/Color/operations/OklchOperations.ts
+++ b/src/TokenTypes/Color/operations/OklchOperations.ts
@@ -1,0 +1,93 @@
+import type { Color, InternalCreate } from '../Color.js';
+import type { Oklch } from '../types.js';
+
+/**
+ * Oklch-space operations. Oklch is the authoring-friendly polar form of Oklab:
+ * holding L constant while rotating hue keeps perceived lightness even, which is
+ * exactly what makes it pleasant for generating balanced color palettes.
+ */
+export class OklchOperations {
+  #color: Color;
+  #new: InternalCreate;
+
+  constructor(color: Color, createInternal: InternalCreate) {
+    this.#color = color;
+    this.#new = createInternal;
+  }
+
+  #oklch(): Oklch {
+    return this.#color.asOklch();
+  }
+
+  lightness(): number;
+  lightness(value: number): Color;
+  lightness(value?: number): number | Color {
+    if (value === undefined) {
+      return this.#oklch()[0];
+    }
+
+    const [, c, h] = this.#oklch();
+
+    return this.#new('oklch', [value, c, h], this.#color.alpha);
+  }
+
+  chroma(): number;
+  chroma(value: number): Color;
+  chroma(value?: number): number | Color {
+    if (value === undefined) {
+      return this.#oklch()[1];
+    }
+
+    const [l, , h] = this.#oklch();
+
+    return this.#new('oklch', [l, value, h], this.#color.alpha);
+  }
+
+  hue(): number;
+  hue(value: number): Color;
+  hue(value?: number): number | Color {
+    if (value === undefined) {
+      return this.#oklch()[2];
+    }
+
+    const [l, c] = this.#oklch();
+
+    return this.#new('oklch', [l, c, value], this.#color.alpha);
+  }
+
+  rotateHue(degrees: number): Color {
+    const newHue = (this.#oklch()[2] + degrees) % 360;
+
+    return this.hue(newHue < 0 ? newHue + 360 : newHue);
+  }
+
+  complement(): Color {
+    return this.rotateHue(180);
+  }
+
+  /** Lighten by adjusting L proportionally (holding chroma and hue) */
+  lighten(amount: number): Color {
+    const [L, c, h] = this.#oklch();
+
+    return this.#new('oklch', [L + amount * L, c, h], this.#color.alpha);
+  }
+
+  darken(amount: number): Color {
+    return this.lighten(-amount);
+  }
+
+  /** Increase chroma by an absolute amount (holding L and hue) */
+  saturate(amount: number): Color {
+    const [L, c, h] = this.#oklch();
+
+    return this.#new('oklch', [L, Math.max(0, c + amount), h], this.#color.alpha);
+  }
+
+  desaturate(amount: number): Color {
+    return this.saturate(-amount);
+  }
+
+  toString(): string {
+    return this.#color.toString('oklch');
+  }
+}

--- a/src/TokenTypes/Color/parseColorString.ts
+++ b/src/TokenTypes/Color/parseColorString.ts
@@ -7,6 +7,8 @@ import {
   isHSLA,
   isLAB,
   isLCH,
+  isOklab,
+  isOklch,
   isRGB,
   isRGBA,
   isXYZ,
@@ -26,6 +28,14 @@ const lchRegex =
   /^lch\([\s]*([0-9]+(?:\.[0-9]+)?)[\s,]*([0-9]+(?:\.[0-9]+)?)[\s,]*([0-9]+(?:\.[0-9]+)?)(?:[\s]*\/[\s]*([0-9]*\.?[0-9]+))?\)$/i;
 const xyzRegex =
   /^xyz\([\s]*([0-9]+(?:\.[0-9]+)?)[\s,]*([0-9]+(?:\.[0-9]+)?)[\s,]*([0-9]+(?:\.[0-9]+)?)(?:[\s]*\/[\s]*([0-9]*\.?[0-9]+))?\)$/i;
+const oklabRegex =
+  /^oklab\([\s]*([0-9]*\.?[0-9]+%?)[\s,]*([+-]?[0-9]*\.?[0-9]+)[\s,]*([+-]?[0-9]*\.?[0-9]+)(?:[\s]*\/[\s]*([0-9]*\.?[0-9]+))?\)$/i;
+const oklchRegex =
+  /^oklch\([\s]*([0-9]*\.?[0-9]+%?)[\s,]*([0-9]*\.?[0-9]+)[\s,]*([+-]?[0-9]*\.?[0-9]+)(?:deg)?(?:[\s]*\/[\s]*([0-9]*\.?[0-9]+))?\)$/i;
+
+/** Oklab/Oklch lightness accepts either a 0-1 number or a 0%-100% percentage. */
+const parseOkLightness = (raw: string): number =>
+  raw.trim().endsWith('%') ? parseFloat(raw) / 100 : parseFloat(raw);
 
 const parseHSLString = (c: string): ParsedColor => {
   const m = c.match(hslRegex);
@@ -87,6 +97,36 @@ const parseXYZString = (c: string): ParsedColor => {
   return { space: 'xyz', data: [x, y, z], alpha };
 };
 
+const parseOklabString = (c: string): ParsedColor => {
+  const m = c.match(oklabRegex);
+
+  if (!m) {
+    throw new Error(`Cannot parse Oklab from "${c}"`);
+  }
+
+  const L = parseOkLightness(m[1]!);
+  const a = parseFloat(m[2]!);
+  const b = parseFloat(m[3]!);
+  const alpha = m[4] !== undefined ? parseFloat(m[4]) : 1;
+
+  return { space: 'oklab', data: [L, a, b], alpha };
+};
+
+const parseOklchString = (c: string): ParsedColor => {
+  const m = c.match(oklchRegex);
+
+  if (!m) {
+    throw new Error(`Cannot parse Oklch from "${c}"`);
+  }
+
+  const L = parseOkLightness(m[1]!);
+  const C = parseFloat(m[2]!);
+  const H = normalizeDegrees(parseFloat(m[3]!));
+  const alpha = m[4] !== undefined ? parseFloat(m[4]) : 1;
+
+  return { space: 'oklch', data: [L, C, H], alpha };
+};
+
 export const parseColorString = (c: string): ParsedColor => {
   const trimmed = c.trim();
 
@@ -139,6 +179,16 @@ export const parseColorString = (c: string): ParsedColor => {
   // LCH
   if (isLCH(trimmed)) {
     return parseLCHString(trimmed);
+  }
+
+  // Oklab
+  if (isOklab(trimmed)) {
+    return parseOklabString(trimmed);
+  }
+
+  // Oklch
+  if (isOklch(trimmed)) {
+    return parseOklchString(trimmed);
   }
 
   // XYZ

--- a/src/TokenTypes/Color/types.ts
+++ b/src/TokenTypes/Color/types.ts
@@ -7,6 +7,9 @@ export type HSL = readonly [hue: number, saturation: number, lightness: number];
 export type XYZ = readonly [x: number, y: number, z: number];
 export type LAB = readonly [lightness: number, a: number, b: number];
 export type LCH = readonly [lightness: number, chroma: number, hue: number];
+// Oklab / Oklch (Björn Ottosson's perceptual space + its polar form)
+export type Oklab = readonly [lightness: number, a: number, b: number];
+export type Oklch = readonly [lightness: number, chroma: number, hue: number];
 export type CMYK = readonly [cyan: number, magenta: number, yellow: number, black: number];
 
 // Alpha variants using the helper type
@@ -15,6 +18,8 @@ export type HSLA = WithAlpha<HSL>;
 export type XYZA = WithAlpha<XYZ>;
 export type LABA = WithAlpha<LAB>;
 export type LCHA = WithAlpha<LCH>;
+export type OklabA = WithAlpha<Oklab>;
+export type OklchA = WithAlpha<Oklch>;
 export type CMYKA = WithAlpha<CMYK>;
 
 export type ColorBlindnessType =
@@ -42,5 +47,9 @@ export type ColorFormat =
   | 'laba'
   | 'lch'
   | 'lcha'
+  | 'oklab'
+  | 'oklaba'
+  | 'oklch'
+  | 'oklcha'
   | 'named'
   | 'xkcd';

--- a/src/TokenTypes/Color/util.ts
+++ b/src/TokenTypes/Color/util.ts
@@ -108,6 +108,31 @@ const formats = {
     ],
     hasOptionalParams: true,
   },
+  // Oklab/Oklch use modern CSS syntax: space-separated, L accepts a unit
+  // number (0-1) or a percentage, a/b are signed. Numeric bounds are kept
+  // permissive since Oklch can legitimately express out-of-sRGB-gamut colors.
+  oklab: {
+    regex:
+      /^oklab\([\s]*([0-9]*\.?[0-9]+%?)[\s,]*([+-]?[0-9]*\.?[0-9]+)[\s,]*([+-]?[0-9]*\.?[0-9]+)(?:[\s]*\/[\s]*([0-9]*\.?[0-9]+))?\)$/i,
+    validators: [
+      (l: number) => inRange(0, 100, l), // L: 0-1 or 0%-100%
+      (a: number) => inRange(-2, 2, a), // a
+      (b: number) => inRange(-2, 2, b), // b
+      inUnit, // alpha: 0 to 1
+    ],
+    hasOptionalParams: true,
+  },
+  oklch: {
+    regex:
+      /^oklch\([\s]*([0-9]*\.?[0-9]+%?)[\s,]*([0-9]*\.?[0-9]+)[\s,]*([+-]?[0-9]*\.?[0-9]+)(?:deg)?(?:[\s]*\/[\s]*([0-9]*\.?[0-9]+))?\)$/i,
+    validators: [
+      (l: number) => inRange(0, 100, l), // L: 0-1 or 0%-100%
+      (c: number) => inRange(0, 2, c), // C
+      inAnyDegrees, // H: any degrees (normalized)
+      inUnit, // alpha: 0 to 1
+    ],
+    hasOptionalParams: true,
+  },
 } as const;
 
 const isValidColor = (format: keyof typeof formats): ((color: string) => boolean) => {
@@ -155,6 +180,8 @@ export const isHSL: (color: string) => boolean = isValidColor('hsl');
 export const isHSLA: (color: string) => boolean = isValidColor('hsla');
 export const isLAB: (color: string) => boolean = isValidColor('lab');
 export const isLCH: (color: string) => boolean = isValidColor('lch');
+export const isOklab: (color: string) => boolean = isValidColor('oklab');
+export const isOklch: (color: string) => boolean = isValidColor('oklch');
 export const isXYZ: (color: string) => boolean = isValidColor('xyz');
 
 /**


### PR DESCRIPTION
## Summary

Adds **Oklab** (Björn Ottosson's perceptual space) and **Oklch** (its polar, authoring-friendly form) as first-class color spaces, implements CSS Color 4 gamut mapping on the sRGB-emitting paths, and adds a node-free `teikn/color` subpath export so `Color` can be consumed standalone in the browser.

## Task A — Oklab & Oklch spaces
Followed the existing LAB/LCH pattern end-to-end — no parallel machinery:
- `types.ts` — `Oklab`/`Oklch` tuples + `OklabA`/`OklchA` + `ColorFormat` entries
- `conversions.ts` — `RGBToOklab`, `OklabToRGB`, `OklabToOklch`, `OklchToOklab`, via **linear sRGB** (reusing the existing linearize/gamma), not XYZ
- `ColorSpace.ts` — added to the `Space` union, `SpaceData`, `direct` adjacency, and the shortest-`paths` table (the subgraph attaches via the single `rgb↔oklab` edge)
- `operations/OklabOperations.ts` (`lightness`/`a`/`b`, CSS-accurate linear `mix`, `lighten`/`darken`) and `operations/OklchOperations.ts` (`lightness`/`chroma`/`hue`, `rotateHue`, `lighten`/`darken`, `saturate`/`desaturate`, `complement`)
- `Color.ts` — `.oklab`/`.oklch` getters, `fromOklab`/`fromOklch`, `asOklab(A)`/`asOklch(A)`, formatters, `toString` cases
- Parsing — `oklab(L a b)` / `oklch(L C h)` with `%` lightness, `/ alpha`, and space-or-comma separators

## Task B — gamut mapping
`OklabToRGB` applies CSS Color 4 gamut mapping: if the direct linear conversion is in-gamut it's used as-is; otherwise it holds **L and h** and **binary-searches reduced chroma** with a clip + Oklab-ΔE (JND ≈ 0.02) acceptance test — never a naive per-channel clip. It's placed on that one function because `oklab→rgb` is the sole edge out of the oklab/oklch subgraph, so it targets exactly the Oklab/Oklch-sourced sRGB emits with no special-casing in `Color`. In-gamut colors are unaffected.

## Task C — `teikn/color` export
`./color` added to `package.json` and `jsr.json`. The Color subtree only leaves itself via two dependency-free leaf modules (`ref-guard.js`, `utils.js`), so the graph is node-free. Verified with `esbuild --bundle --minify --format=esm` (no `--platform=node`): **zero errors, node-free**.

**Bundle size (Color subtree): 16,496 → 17,785 gzip bytes (+~1.3 KB)** for the whole Oklab/Oklch + gamut-mapping addition.

## Testing
- New `oklab.test.ts` — **49 tests**: reference values checked against culori, exact hex↔oklab↔hex and oklab↔oklch round-trips, string parse/serialize, gamut mapping on out-of-gamut Oklch inputs, operation namespaces, factories, immutability
- Full suite **2080 pass** on both Bun and vitest (Node); `tsc`, lint, and format all clean

## Not included (deliberate)
- **Default `.mix()` space unchanged** (still sRGB). Recommendation: flip it to Oklab in the next **major** (3.0.0) — it's the perceptually correct default and matches CSS `color-mix(in oklab, …)`, but it visibly changes every existing gradient/tint/shade, so it's breaking. `color.oklab.mix(other)` is available today for opt-in.
- **`teikn/color/vision` split skipped** — `simulateColorBlindness`/`deltaE` are instance methods; actually shaving the base floor would require removing them from the class (an API break), which the everyday-methods guidance rules out.
- **Version not bumped** — the `beta.6` changelog heading is unreleased; the version bump across `package.json`/`jsr.json`/`src/version.ts` is a separate release step per repo convention.