### PR TITLE
Remove unused CMYK color types

### DIFF
--- a/src/TokenTypes/Color/types.ts
+++ b/src/TokenTypes/Color/types.ts
@@ -10,7 +10,6 @@ export type LCH = readonly [lightness: number, chroma: number, hue: number];
 // Oklab / Oklch (Björn Ottosson's perceptual space + its polar form)
 export type Oklab = readonly [lightness: number, a: number, b: number];
 export type Oklch = readonly [lightness: number, chroma: number, hue: number];
-export type CMYK = readonly [cyan: number, magenta: number, yellow: number, black: number];
 
 // Alpha variants using the helper type
 export type RGBA = WithAlpha<RGB>;
@@ -20,7 +19,6 @@ export type LABA = WithAlpha<LAB>;
 export type LCHA = WithAlpha<LCH>;
 export type OklabA = WithAlpha<Oklab>;
 export type OklchA = WithAlpha<Oklch>;
-export type CMYKA = WithAlpha<CMYK>;
 
 export type ColorBlindnessType =
   | 'protanopia'


### PR DESCRIPTION
Drops `CMYK` and `CMYKA` from `src/TokenTypes/Color/types.ts`.

They were type-only declarations with no backing implementation — `Color` has no `asCMYK`/`fromCMYK` conversions and the types aren't re-exported from any public entry — so nothing in the codebase (or downstream) consumed them. Rather than ship an unbacked type, this removes the dead surface; it can be reintroduced alongside real CMYK conversion support if a print target lands later.

- `tsc` clean, format/lint clean
- Full test suite unaffected (no references existed)