### PR TITLE
Bump version to 2.0.0-beta.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,15 @@
   toolkit, with an import graph that reaches no generators and no `node:*` builtins — so it
   tree-shakes clean and bundles for the browser without Node shims. (The main `teikn` barrel still
   transitively imports `node:os`/`node:fs` via the generators.)
+- **`buildPlatforms` helper.** Generate a separate flat artifact set per platform (web, iOS,
+  Android, Typst, …) from one shared base plus small per-platform deltas:
+  `buildPlatforms({ base, platforms: { web: null, mobile }, generators: (platform) => […], outDir })`.
+  Each delta is collapsed into the base at build time via `composeTokenSets` — flat values, no
+  `modes` block or `[data-theme]` selector — which suits a different _renderer_ (iOS, Typst) rather
+  than a runtime theme toggle. `generators` (and optional `plugins`/`themes`) is a per-platform
+  factory, not an array, so each `Teikn` build gets fresh, correctly-wired generator instances and a
+  platform can emit an entirely different generator set. Runs sequentially and returns
+  `Map<platform, TransformResult>`.
 
 ## 2.0.0-beta.5
 

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@shawnrice/teikn",
-  "version": "2.0.0-beta.5",
+  "version": "2.0.0-beta.6",
   "exports": {
     ".": "./index.ts",
     "./color": "./src/TokenTypes/Color/index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teikn",
-  "version": "2.0.0-beta.5",
+  "version": "2.0.0-beta.6",
   "description": "Generate design tokens",
   "keywords": [
     "design",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '2.0.0-beta.5';
+export const version = '2.0.0-beta.6';


### PR DESCRIPTION
Release prep for `2.0.0-beta.6`: version bumped in `package.json`, `jsr.json`, and `src/version.ts`, and the `buildPlatforms` entry added to the changelog (Oklab/Oklch + `teikn/color` entries were already staged under this version).

Merging this, then pushing a `v2.0.0-beta.6` tag, triggers the `beta`-tagged publish to npm / GitHub Packages / JSR.

See CHANGELOG.md for the full beta.6 notes.