### PR TITLE
Native-space color serialization + composite color-token references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,53 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- **`ColorTransformPlugin` now normalizes colors nested inside composite tokens**, not just
+  standalone `color` tokens. A box shadow, border, or gradient stop is re-based into the configured
+  space along with the color tokens, so `ColorTransformPlugin({ type: 'oklch' })` no longer leaves a
+  shadow's color as `rgb` while the color tokens become `oklch`. Nested colors are re-based into the
+  target color space; note that purely-notational formats (`hex`, `hex3`, `named`, `xkcd`, and the
+  forced-alpha `rgba`/`hsla`/… variants on opaque colors) have no native space of their own, so a
+  nested color under those renders in the canonical notation of the underlying space (e.g. `hex` →
+  `rgb(…)`), while a standalone `color` token still emits the exact requested notation.
+
+- **`BoxShadow` (and multi-layer `BoxShadowList`) accept a per-field `{ref}` color** instead of
+  throwing, mirroring `Border` / `Typography`.
+  `new BoxShadow({ offsetY: 2, blur: 8, color: '{color.ink}' })` (or the shorthand
+  `"0 2px 8px {color.ink}"`) now holds the reference and resolves it per-field: in CSS it emits
+  `var(--color-ink)`, and in DTCG it emits the `{color.ink}` alias. Both `BoxShadow` and
+  `BoxShadowList` implement the `RefFields` protocol, so `BoxShadow.color` is now typed
+  `Color | string` and a `{ref}` inside any layer of a stacked shadow resolves too.
+
+- **Gradient stops accept per-field `{ref}` colors.** `LinearGradient`, `RadialGradient`, and
+  `GradientList` implement the `RefFields` protocol, so a stop can reference a color token —
+  `new LinearGradient(180, [['{color.brand}', '0%'], ['#000', '100%']])` no longer throws. A
+  referenced stop resolves per-field: `var(--color-brand)` in CSS and a `{color.brand}` alias in
+  DTCG, with `validate()` flagging unresolved stop refs (as `field "stops.color"`).
+  `GradientStop.color` is now typed `Color | string`. As part of this, `resolveReferences` /
+  `validate` now recurse into arrays, so refs buried inside any array-shaped composite field resolve
+  and validate.
+
+### Changed
+
+- **BREAKING: `Color.toString()` now serializes in the color's authored space, not `rgb`.**
+  Previously, calling `toString()` with no format argument always emitted `rgb()`/`rgba()`,
+  discarding the space a color was authored in. It now serializes in the color's native space — so a
+  color created from `oklch(…)` round-trips as `oklch(…)`, one from `hsl(…)` stays `hsl(…)`, and
+  hex/rgb/named colors stay `rgb(…)` (hex, named, and numeric input all parse into the `rgb` space).
+  Reading the native space is a cache hit with no conversion, so this is lossless apart from decimal
+  rounding — it avoids the previous round trip through 8-bit, gamut-clipped `rgb`. This also fixes
+  **box-shadow colors**, whose serializer calls the formatless `toString()`: an oklch-authored
+  shadow color now emits oklch instead of rgb.
+
+  To restore the old behavior, pass an explicit format: `color.toString('rgb')`, or normalize whole
+  token sets with `ColorTransformPlugin({ type: 'rgb' })`. A new `'native'` value of `ColorFormat`
+  names this behavior explicitly (`toString('native')` === `toString()`). Note that color operations
+  return a color in their working space (e.g. `lighten`/`setHue` work in HSL), so their formatless
+  output is now `hsl(…)` — pass an explicit format if you need a specific space.
+
 ## 2.0.0-beta.6
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -280,7 +280,17 @@ c1.toString('rgba'); // 'rgba(70, 130, 180, 1)'
 c1.toString('hsl'); // 'hsl(207, 44%, 49%)'
 c1.toString('lab'); // 'lab(54.3, -5.6, -32.1)'
 c1.toString('lch'); // 'lch(54.3, 32.6, 260)'
+c1.toString('oklch'); // 'oklch(0.588 0.09934 245.739)'
 c1.toString('xkcd'); // nearest XKCD color name
+
+// No format? Serializes in the color's *authored* space (lossless — no gamut
+// clip, no 8-bit round trip). So oklch stays oklch and only rounds decimals.
+new Color('oklch(0.7 0.15 200)').toString(); // 'oklch(0.7 0.15 200)'
+new Color('#4682b4').toString(); // 'rgb(70, 130, 180)'  (hex parses to rgb)
+c1.toString('native'); // same as toString() — names the default explicitly
+// This is what box-shadow (and other) serializers use, so an oklch shadow color
+// emits oklch. Want a fixed space everywhere? Pass a format, or use
+// ColorTransformPlugin({ type: 'rgb' }) to normalize a whole token set.
 
 // Access raw values
 c1.asRGB(); // [70, 130, 180]
@@ -337,6 +347,10 @@ const inset = new BoxShadow(0, 1, 4, 0, 'rgba(0,0,0,.1)', true);
 // From CSS string
 const parsed = new BoxShadow('0 4px 16px rgba(0,0,0,.15)');
 
+// The color may be a per-field {ref} — resolved later (→ var(--…) in CSS,
+// a DTCG alias in Dtcg), rather than throwing like a bare Color would.
+const linked = new BoxShadow({ offsetY: 2, blur: 8, color: '{color.ink}' });
+
 // Immutable updates
 shadow.with({ blur: 16, spread: 4 });
 shadow.with({ color: new Color('steelblue'), inset: true });
@@ -346,7 +360,7 @@ shadow.offsetX; // 0
 shadow.offsetY; // 2
 shadow.blur; // 8
 shadow.spread; // 0
-shadow.color; // Color
+shadow.color; // Color | string  (a string when it holds an unresolved {ref})
 shadow.inset; // false
 
 shadow.scale(2); // scale all numeric values
@@ -445,6 +459,13 @@ const radial = new RadialGradient({ shape: 'circle' }, [
 ]);
 
 linear.toString(); // 'linear-gradient(135deg, #4682b4 0%, #dc143c 100%)'
+
+// A stop color may be a per-field {ref} to a color token — resolved later
+// (→ var(--…) in CSS, a DTCG alias in Dtcg), rather than throwing.
+const branded = new LinearGradient(180, [
+  ['{color.brand}', '0%'],
+  ['#000', '100%'],
+]);
 ```
 
 ### Transition
@@ -557,15 +578,15 @@ const writer = new Teikn({
 });
 ```
 
-| Plugin                    | Description                                                                                                           |
-| ------------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| **ColorTransformPlugin**  | Normalizes color tokens to a specific format (`hex`, `rgb`, `hsl`, `lab`, `lch`, `xyz`)                               |
-| **StripTypePrefixPlugin** | Opt out of the built-in type prefixing (e.g., keep `primary` as `primary` instead of `color-primary`)                 |
-| **ScssQuoteValuePlugin**  | Wraps font and font-family values in `unquote()` for SCSS compatibility                                               |
-| **RemUnitPlugin**         | Converts px Dimensions to rem (or configurable unit). Options: `base` (default 16), `targetUnit` (default `'rem'`)    |
-| **AlphaMultiplyPlugin**   | Flattens semi-transparent colors against a background via alpha blending. Options: `background` (default `'#ffffff'`) |
-| **NameConventionPlugin**  | Transforms token names to `camelCase`, `kebab-case`, `snake_case`, `PascalCase`, or `SCREAMING_SNAKE`                 |
-| **DeprecationPlugin**     | Marks tokens as deprecated with optional replacement references                                                       |
+| Plugin                    | Description                                                                                                                                               |
+| ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **ColorTransformPlugin**  | Normalizes colors to a specific format (`hex`, `rgb`, `hsl`, `lab`, `lch`, `oklab`, `oklch`, `xyz`), including colors nested in shadows/borders/gradients |
+| **StripTypePrefixPlugin** | Opt out of the built-in type prefixing (e.g., keep `primary` as `primary` instead of `color-primary`)                                                     |
+| **ScssQuoteValuePlugin**  | Wraps font and font-family values in `unquote()` for SCSS compatibility                                                                                   |
+| **RemUnitPlugin**         | Converts px Dimensions to rem (or configurable unit). Options: `base` (default 16), `targetUnit` (default `'rem'`)                                        |
+| **AlphaMultiplyPlugin**   | Flattens semi-transparent colors against a background via alpha blending. Options: `background` (default `'#ffffff'`)                                     |
+| **NameConventionPlugin**  | Transforms token names to `camelCase`, `kebab-case`, `snake_case`, `PascalCase`, or `SCREAMING_SNAKE`                                                     |
+| **DeprecationPlugin**     | Marks tokens as deprecated with optional replacement references                                                                                           |
 
 ### Expand Plugins
 

--- a/src/Generators/Html.ts
+++ b/src/Generators/Html.ts
@@ -834,7 +834,7 @@ export class Html extends Generator<HtmlOpts> {
               [
                 `<div class="gradient-stop-item">`,
                 `<div class="gradient-stop-swatch" style="background:${escapeHtml(s.color.toString())}"></div>`,
-                `<div class="gradient-stop-hex">${escapeHtml(s.color.hex)}</div>`,
+                `<div class="gradient-stop-hex">${escapeHtml(typeof s.color === 'string' ? s.color : s.color.hex)}</div>`,
                 s.position
                   ? `<div class="gradient-stop-label">${escapeHtml(s.position)}</div>`
                   : '',

--- a/src/Generators/color-ref-matrix.test.ts
+++ b/src/Generators/color-ref-matrix.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, test } from 'bun:test';
+
+import { testOpts } from '../fixtures/testOpts.js';
+import { ColorTransformPlugin } from '../Plugins/ColorTransformPlugin.js';
+import type { Token } from '../Token.js';
+import { Border } from '../TokenTypes/Border.js';
+import { BoxShadow, BoxShadowList } from '../TokenTypes/BoxShadow.js';
+import { Color } from '../TokenTypes/Color/index.js';
+import { GradientList, LinearGradient, RadialGradient } from '../TokenTypes/Gradient.js';
+import { validate } from '../validate.js';
+import { CssVars } from './CssVars.js';
+import { DtcgGenerator } from './Dtcg.js';
+import { ScssVars } from './ScssVars.js';
+
+// One matrix row per value type that carries a color and supports per-field
+// `{ref}` colors. Every behavior below runs for every type so the coverage is
+// symmetric and a regression in any one cell fails loudly.
+type MatrixCase = {
+  name: string;
+  type: string;
+  /** Composite value holding a `{ref}` color. */
+  withRef: (ref: string) => unknown;
+  /** Composite value holding a concrete color (for the plugin re-base test). */
+  withColor: (color: Color) => unknown;
+  /** Substring the CSS var value must contain once the ref resolves. */
+  cssContains: string;
+  /** Reach into a DTCG `$value` and return the aliased color slot. */
+  dtcgAlias: (value: any) => unknown;
+  /** Field label the validate() message reports for an unresolved ref. */
+  validateField: RegExp;
+  /** Reach the (concrete) nested color of a transformed value. */
+  nestedColor: (value: unknown) => Color;
+};
+
+const CASES: MatrixCase[] = [
+  {
+    name: 'Border',
+    type: 'border',
+    withRef: ref => new Border({ width: '1px', style: 'solid', color: ref }),
+    withColor: color => new Border({ width: '1px', style: 'solid', color }),
+    cssContains: '1px solid var(--ink)',
+    dtcgAlias: v => v.color,
+    validateField: /field "color"/,
+    nestedColor: v => (v as Border).color as Color,
+  },
+  {
+    name: 'BoxShadow',
+    type: 'shadow',
+    withRef: ref => new BoxShadow({ offsetY: 2, blur: 8, color: ref }),
+    withColor: color => new BoxShadow({ offsetY: 2, blur: 8, color }),
+    cssContains: '0 2px 8px var(--ink)',
+    dtcgAlias: v => v.color,
+    validateField: /field "color"/,
+    nestedColor: v => (v as BoxShadow).color as Color,
+  },
+  {
+    name: 'BoxShadowList',
+    type: 'shadow',
+    withRef: ref => new BoxShadowList([new BoxShadow({ offsetY: 2, blur: 8, color: ref })]),
+    withColor: color => new BoxShadowList([new BoxShadow({ offsetY: 2, blur: 8, color })]),
+    cssContains: '0 2px 8px var(--ink)',
+    dtcgAlias: v => v[0].color,
+    validateField: /field "layers\.color"/,
+    nestedColor: v => (v as BoxShadowList).layers[0]!.color as Color,
+  },
+  {
+    name: 'LinearGradient',
+    type: 'gradient',
+    withRef: ref =>
+      new LinearGradient(180, [
+        [ref, '0%'],
+        ['#000', '100%'],
+      ]),
+    withColor: color =>
+      new LinearGradient(180, [
+        [color, '0%'],
+        ['#000', '100%'],
+      ]),
+    cssContains: 'linear-gradient(to bottom, var(--ink) 0%',
+    dtcgAlias: v => v[0].color,
+    validateField: /field "stops\.color"/,
+    nestedColor: v => (v as LinearGradient).stops[0]!.color as Color,
+  },
+  {
+    name: 'RadialGradient',
+    type: 'gradient',
+    withRef: ref =>
+      new RadialGradient({ shape: 'circle' }, [
+        [ref, '0%'],
+        ['#000', '100%'],
+      ]),
+    withColor: color =>
+      new RadialGradient({ shape: 'circle' }, [
+        [color, '0%'],
+        ['#000', '100%'],
+      ]),
+    cssContains: 'radial-gradient(circle, var(--ink) 0%',
+    dtcgAlias: v => v[0].color,
+    validateField: /field "stops\.color"/,
+    nestedColor: v => (v as RadialGradient).stops[0]!.color as Color,
+  },
+  {
+    name: 'GradientList',
+    type: 'gradient',
+    withRef: ref =>
+      new GradientList([
+        new LinearGradient(180, [
+          [ref, '0%'],
+          ['#000', '100%'],
+        ]),
+      ]),
+    withColor: color =>
+      new GradientList([
+        new LinearGradient(180, [
+          [color, '0%'],
+          ['#000', '100%'],
+        ]),
+      ]),
+    cssContains: 'linear-gradient(to bottom, var(--ink) 0%',
+    dtcgAlias: v => v[0][0].color,
+    validateField: /field "layers\.stops\.color"/,
+    nestedColor: v => (v as GradientList).layers[0]!.stops[0]!.color as Color,
+  },
+];
+
+const inkToken: Token = { name: 'ink', type: 'color', value: new Color(0, 0, 0) };
+
+describe('color-ref matrix (all ref-carrying value types)', () => {
+  for (const c of CASES) {
+    describe(c.name, () => {
+      test('authoring a {ref} color does not throw', () => {
+        expect(() => c.withRef('{ink}')).not.toThrow();
+      });
+
+      test('a resolved {ref} emits var(--…) in CSS', () => {
+        const tokens: Token[] = [
+          inkToken,
+          { name: 'target', type: c.type, value: c.withRef('{ink}') },
+        ];
+        const css = new CssVars(testOpts).generate(tokens);
+        expect(css).toContain(c.cssContains);
+        expect(css).not.toContain('{ink}');
+      });
+
+      test('a resolved {ref} emits a $variable in SCSS', () => {
+        const tokens: Token[] = [
+          inkToken,
+          { name: 'target', type: c.type, value: c.withRef('{ink}') },
+        ];
+        const scss = new ScssVars(testOpts).generate(tokens);
+        // Same shape as the CSS output, but the ref renders as an SCSS `$ink`.
+        expect(scss).toContain(c.cssContains.replace('var(--ink)', '$ink'));
+        expect(scss).not.toContain('{ink}');
+      });
+
+      test('a {ref} color inside a mode value resolves in that mode block', () => {
+        const tokens: Token[] = [
+          inkToken,
+          {
+            name: 'target',
+            type: c.type,
+            value: c.withColor(new Color(255, 255, 255)),
+            modes: { dark: c.withRef('{ink}') },
+          },
+        ];
+        const css = new CssVars(testOpts).generate(tokens);
+        expect(css).toContain('[data-theme="dark"]');
+        // The var(--ink) reference only comes from the dark mode value.
+        expect(css).toContain(c.cssContains);
+        expect(css).not.toContain('{ink}');
+      });
+
+      test('a resolved {ref} becomes a DTCG alias', () => {
+        const tokens: Token[] = [
+          inkToken,
+          { name: 'target', type: c.type, value: c.withRef('{ink}') },
+        ];
+        const dtcg = JSON.parse(new DtcgGenerator({ hierarchical: false }).generate(tokens));
+        expect(c.dtcgAlias(dtcg.target.$value)).toBe('{ink}');
+      });
+
+      test('an unresolved {ref} is flagged by validate()', () => {
+        const result = validate([{ name: 'target', type: c.type, value: c.withRef('{missing}') }]);
+        expect(result.valid).toBe(false);
+        expect(result.issues.some(i => c.validateField.test(i.message))).toBe(true);
+      });
+
+      test('ColorTransformPlugin re-bases the nested color into the target space', () => {
+        const plugin = new ColorTransformPlugin({ type: 'hsl' });
+        const result = plugin.transform({
+          name: 'target',
+          type: c.type,
+          value: c.withColor(new Color(255, 0, 0)),
+        });
+        const color = c.nestedColor(result.value);
+        expect(color).toBeInstanceOf(Color);
+        expect(String(color)).toBe('hsl(0, 100%, 50%)');
+      });
+    });
+  }
+
+  test('a circular reference through a gradient stop is detected', () => {
+    const tokens: Token[] = [
+      { name: 'a', type: 'color', value: '{grad}' },
+      {
+        name: 'grad',
+        type: 'gradient',
+        value: new LinearGradient(180, [
+          ['{a}', '0%'],
+          ['#000', '100%'],
+        ]),
+      },
+    ];
+    const result = validate(tokens);
+    expect(result.issues.some(i => /[Cc]ircular/.test(i.message))).toBe(true);
+  });
+
+  test('a circular reference through a shadow-list layer is detected', () => {
+    const tokens: Token[] = [
+      { name: 'a', type: 'color', value: '{stack}' },
+      {
+        name: 'stack',
+        type: 'shadow',
+        value: new BoxShadowList([new BoxShadow({ offsetY: 2, blur: 8, color: '{a}' })]),
+      },
+    ];
+    const result = validate(tokens);
+    expect(result.issues.some(i => /[Cc]ircular/.test(i.message))).toBe(true);
+  });
+
+  test('hex-family formats render a nested color in the space canonical notation (documented caveat)', () => {
+    // `hex` has no native space, so a nested color normalized to hex renders as
+    // rgb() — while a standalone color token still emits exact hex.
+    const plugin = new ColorTransformPlugin({ type: 'hex' });
+    const shadow = plugin.transform({
+      name: 's',
+      type: 'shadow',
+      value: new BoxShadow({ offsetY: 2, blur: 8, color: new Color(255, 0, 0) }),
+    });
+    expect(String((shadow.value as BoxShadow).color)).toBe('rgb(255, 0, 0)');
+
+    const bare = plugin.transform({ name: 'c', type: 'color', value: new Color(255, 0, 0) });
+    expect(bare.value).toBe('#ff0000');
+  });
+});

--- a/src/Generators/typography-border-values.test.ts
+++ b/src/Generators/typography-border-values.test.ts
@@ -4,8 +4,10 @@ import { composite } from '../builders.js';
 import { testOpts } from '../fixtures/testOpts.js';
 import type { Token } from '../Token.js';
 import { Border } from '../TokenTypes/Border.js';
+import { BoxShadow, BoxShadowList } from '../TokenTypes/BoxShadow.js';
 import { Color } from '../TokenTypes/Color/index.js';
 import { Dimension } from '../TokenTypes/Dimension.js';
+import { LinearGradient } from '../TokenTypes/Gradient.js';
 import { Typography } from '../TokenTypes/Typography.js';
 import { validate } from '../validate.js';
 import { CssVars } from './CssVars.js';
@@ -211,6 +213,116 @@ describe('per-field references inside a wrapper resolve (RefFields protocol)', (
     // Resolved to the `line` color token's instance → emitted as a var() ref.
     expect(css).toContain('--border-focus: 2px solid var(--line);');
     expect(css).not.toContain('{line}');
+  });
+
+  test('a BoxShadow color `{ref}` resolves and emits var(--…) in CSS', () => {
+    const tokens: Token[] = [
+      { name: 'ink', type: 'color', value: new Color(0, 0, 0) },
+      {
+        name: 'shadowMd',
+        type: 'shadow',
+        value: new BoxShadow({ offsetY: 2, blur: 8, color: '{ink}' }),
+      },
+    ];
+    const css = new CssVars(testOpts).generate(tokens);
+    expect(css).toContain('--shadow-md: 0 2px 8px var(--ink);');
+    expect(css).not.toContain('{ink}');
+  });
+
+  test('a resolved BoxShadow color `{ref}` becomes a DTCG alias', () => {
+    const tokens: Token[] = [
+      { name: 'ink', type: 'color', value: new Color(0, 0, 0) },
+      {
+        name: 'shadowMd',
+        type: 'shadow',
+        value: new BoxShadow({ offsetY: 2, blur: 8, color: '{ink}' }),
+      },
+    ];
+    const dtcg = JSON.parse(new DtcgGenerator({ hierarchical: false }).generate(tokens));
+    expect(dtcg.shadowMd.$value.color).toBe('{ink}');
+  });
+
+  test('an unresolved BoxShadow color reference is flagged by validate()', () => {
+    const result = validate([
+      {
+        name: 'shadowMd',
+        type: 'shadow',
+        value: new BoxShadow({ offsetY: 2, blur: 8, color: '{nope}' }),
+      },
+    ]);
+    expect(result.valid).toBe(false);
+    expect(result.issues.some(i => /Unresolved reference in field "color"/.test(i.message))).toBe(
+      true,
+    );
+  });
+
+  test('a BoxShadowList layer `{ref}` resolves and emits var(--…) in CSS', () => {
+    const tokens: Token[] = [
+      { name: 'ink', type: 'color', value: new Color(0, 0, 0) },
+      {
+        name: 'elevated',
+        type: 'shadow',
+        value: new BoxShadowList([
+          new BoxShadow({ offsetY: 2, blur: 4, color: '{ink}' }),
+          new BoxShadow({ offsetY: 8, blur: 16, color: new Color(51, 51, 51) }),
+        ]),
+      },
+    ];
+    const css = new CssVars(testOpts).generate(tokens);
+    expect(css).toContain('--elevated: 0 2px 4px var(--ink), 0 8px 16px rgb(51, 51, 51);');
+    expect(css).not.toContain('{ink}');
+  });
+
+  test('a Gradient stop `{ref}` resolves and emits var(--…) in CSS', () => {
+    const tokens: Token[] = [
+      { name: 'brand', type: 'color', value: new Color(70, 130, 180) },
+      {
+        name: 'hero',
+        type: 'gradient',
+        value: new LinearGradient(180, [
+          ['{brand}', '0%'],
+          [new Color(0, 0, 0), '100%'],
+        ]),
+      },
+    ];
+    const css = new CssVars(testOpts).generate(tokens);
+    expect(css).toContain(
+      '--hero: linear-gradient(to bottom, var(--brand) 0%, rgb(0, 0, 0) 100%);',
+    );
+    expect(css).not.toContain('{brand}');
+  });
+
+  test('a resolved Gradient stop `{ref}` becomes a DTCG alias', () => {
+    const tokens: Token[] = [
+      { name: 'brand', type: 'color', value: new Color(70, 130, 180) },
+      {
+        name: 'hero',
+        type: 'gradient',
+        value: new LinearGradient(180, [
+          ['{brand}', '0%'],
+          [new Color(0, 0, 0), '100%'],
+        ]),
+      },
+    ];
+    const dtcg = JSON.parse(new DtcgGenerator({ hierarchical: false }).generate(tokens));
+    expect(dtcg.hero.$value[0].color).toBe('{brand}');
+  });
+
+  test('an unresolved Gradient stop reference is flagged by validate()', () => {
+    const result = validate([
+      {
+        name: 'hero',
+        type: 'gradient',
+        value: new LinearGradient(180, [
+          ['{missing}', '0%'],
+          [new Color(0, 0, 0), '100%'],
+        ]),
+      },
+    ]);
+    expect(result.valid).toBe(false);
+    expect(
+      result.issues.some(i => /Unresolved reference in field "stops\.color"/.test(i.message)),
+    ).toBe(true);
   });
 
   test('a Typography fontSize `{ref}` resolves to the referenced dimension', () => {

--- a/src/Generators/value-serializers.ts
+++ b/src/Generators/value-serializers.ts
@@ -1,6 +1,7 @@
 import type { TokenValue } from '../Token.js';
 import { Border } from '../TokenTypes/Border.js';
-import { BoxShadow } from '../TokenTypes/BoxShadow.js';
+import { BoxShadow, BoxShadowList } from '../TokenTypes/BoxShadow.js';
+import { GradientList, LinearGradient, RadialGradient } from '../TokenTypes/Gradient.js';
 import { Transition } from '../TokenTypes/Transition.js';
 import { Typography } from '../TokenTypes/Typography.js';
 import { isFirstClassValue } from '../type-classifiers.js';
@@ -169,6 +170,9 @@ export const stringifyBoxShadowWithRefs = (s: BoxShadow, ref: RefResolver): stri
   return parts.join(' ');
 };
 
+export const stringifyBoxShadowListWithRefs = (s: BoxShadowList, ref: RefResolver): string =>
+  s.layers.map(layer => stringifyBoxShadowWithRefs(layer, ref)).join(', ');
+
 export const stringifyTypographyWithRefs = (t: Typography, ref: RefResolver): string => {
   const sizeLine =
     t.lineHeight !== null
@@ -183,6 +187,13 @@ export const stringifyTypographyWithRefs = (t: Typography, ref: RefResolver): st
 export const stringifyBorderWithRefs = (b: Border, ref: RefResolver): string =>
   [ref(b.width) ?? b.width.toString(), b.style, ref(b.color) ?? b.color.toString()].join(' ');
 
+// Render each stop color through the ref resolver so a stop that references a
+// color token emits `var(--…)` instead of the inlined color.
+export const stringifyGradientWithRefs = (
+  g: LinearGradient | RadialGradient | GradientList,
+  ref: RefResolver,
+): string => g.toCSSWith(color => ref(color) ?? String(color));
+
 export const stringifyWithRefs = (value: TokenValue, ref: RefResolver): string => {
   if (value instanceof Transition) {
     return stringifyTransitionWithRefs(value, ref);
@@ -190,6 +201,18 @@ export const stringifyWithRefs = (value: TokenValue, ref: RefResolver): string =
 
   if (value instanceof BoxShadow) {
     return stringifyBoxShadowWithRefs(value, ref);
+  }
+
+  if (value instanceof BoxShadowList) {
+    return stringifyBoxShadowListWithRefs(value, ref);
+  }
+
+  if (
+    value instanceof LinearGradient ||
+    value instanceof RadialGradient ||
+    value instanceof GradientList
+  ) {
+    return stringifyGradientWithRefs(value, ref);
   }
 
   if (value instanceof Typography) {
@@ -218,11 +241,17 @@ export const visitComponents = (value: unknown, fn: (v: unknown) => void): void 
     }
   } else if (value instanceof BoxShadow) {
     fn(value.color);
+  } else if (value instanceof BoxShadowList) {
+    value.layers.forEach(layer => fn(layer.color));
   } else if (value instanceof Typography) {
     fn(value.fontSize);
   } else if (value instanceof Border) {
     fn(value.width);
     fn(value.color);
+  } else if (value instanceof LinearGradient || value instanceof RadialGradient) {
+    value.stops.forEach(stop => fn(stop.color));
+  } else if (value instanceof GradientList) {
+    value.layers.forEach(layer => layer.stops.forEach(stop => fn(stop.color)));
   }
 };
 

--- a/src/Plugins/ColorTransformPlugin.test.ts
+++ b/src/Plugins/ColorTransformPlugin.test.ts
@@ -1,15 +1,20 @@
 import { describe, expect, test } from 'bun:test';
 
 import type { Token } from '../Token.js';
+import { Border } from '../TokenTypes/Border.js';
+import { BoxShadow } from '../TokenTypes/BoxShadow.js';
 import { Color } from '../TokenTypes/Color/index.js';
+import { LinearGradient } from '../TokenTypes/Gradient.js';
 import { ColorTransformPlugin } from './ColorTransformPlugin.js';
 
 describe('ColorTransformPlugin', () => {
   const makeToken = (name: string, value: unknown): Token => ({ name, type: 'color', value });
 
-  test('tokenType matches color only', () => {
+  test('tokenType matches every type (colors can be nested in composites)', () => {
     const plugin = new ColorTransformPlugin({ type: 'hex' });
-    expect(plugin.tokenType).toBe('color');
+    expect(plugin.tokenType).toBeInstanceOf(RegExp);
+    expect((plugin.tokenType as RegExp).test('shadow')).toBe(true);
+    expect((plugin.tokenType as RegExp).test('color')).toBe(true);
   });
 
   test('transforms a color string to the specified format', () => {
@@ -39,6 +44,53 @@ describe('ColorTransformPlugin', () => {
     const token = makeToken('alias', '{colors.primary.500}');
     const result = plugin.transform(token);
     expect(result).toBe(token);
+  });
+
+  describe('colors nested in composites', () => {
+    test('re-bases a color inside a BoxShadow into the target space', () => {
+      const plugin = new ColorTransformPlugin({ type: 'hsl' });
+      const shadow = new BoxShadow({ offsetY: 2, blur: 8, color: new Color(255, 0, 0) });
+      const result = plugin.transform({ name: 'card', type: 'shadow', value: shadow });
+      const { color } = result.value as BoxShadow;
+      expect(color).toBeInstanceOf(Color);
+      expect(String(color)).toBe('hsl(0, 100%, 50%)');
+    });
+
+    test('re-bases a color inside a Border', () => {
+      const plugin = new ColorTransformPlugin({ type: 'rgb' });
+      const border = new Border({
+        width: '1px',
+        style: 'solid',
+        color: new Color('hsl(0, 100%, 50%)'),
+      });
+      const result = plugin.transform({ name: 'edge', type: 'border', value: border });
+      expect(String((result.value as Border).color)).toBe('rgb(255, 0, 0)');
+    });
+
+    test('re-bases gradient stop colors', () => {
+      const plugin = new ColorTransformPlugin({ type: 'rgb' });
+      const grad = new LinearGradient(180, [
+        [new Color('hsl(0, 100%, 50%)'), '0%'],
+        [new Color('hsl(240, 100%, 50%)'), '100%'],
+      ]);
+      const result = plugin.transform({ name: 'sweep', type: 'gradient', value: grad });
+      const { stops } = result.value as LinearGradient;
+      expect(String(stops[0]!.color)).toBe('rgb(255, 0, 0)');
+      expect(String(stops[1]!.color)).toBe('rgb(0, 0, 255)');
+    });
+
+    test('leaves an unresolved ref color inside a shadow untouched', () => {
+      const plugin = new ColorTransformPlugin({ type: 'rgb' });
+      const shadow = new BoxShadow({ offsetY: 2, blur: 8, color: '{ink}' });
+      const result = plugin.transform({ name: 'card', type: 'shadow', value: shadow });
+      expect((result.value as BoxShadow).color).toBe('{ink}');
+    });
+
+    test('leaves non-color tokens unchanged (referential identity)', () => {
+      const plugin = new ColorTransformPlugin({ type: 'rgb' });
+      const token: Token = { name: 'size', type: 'dimension', value: '16px' };
+      expect(plugin.transform(token)).toBe(token);
+    });
   });
 
   describe('audit', () => {
@@ -87,6 +139,15 @@ describe('ColorTransformPlugin', () => {
       const tokens: Token[] = [{ name: 'size', type: 'dimension', value: '16px' }];
       const issues = plugin.audit!(tokens);
       expect(issues).toHaveLength(0);
+    });
+
+    test('warns for a translucent color nested in a shadow', () => {
+      const plugin = new ColorTransformPlugin({ type: 'hex' });
+      const shadow = new BoxShadow({ offsetY: 2, blur: 8, color: new Color(0, 0, 0, 0.5) });
+      const issues = plugin.audit!([{ name: 'card', type: 'shadow', value: shadow }]);
+      expect(issues).toHaveLength(1);
+      expect(issues[0]!.token).toBe('card');
+      expect(issues[0]!.message).toContain('alpha');
     });
   });
 });

--- a/src/Plugins/ColorTransformPlugin.ts
+++ b/src/Plugins/ColorTransformPlugin.ts
@@ -1,19 +1,30 @@
 import type { Token } from '../Token.js';
 /* eslint-disable @typescript-eslint/no-useless-constructor */
+import { Border } from '../TokenTypes/Border.js';
+import { BoxShadow, BoxShadowList } from '../TokenTypes/BoxShadow.js';
 import { Color } from '../TokenTypes/Color/index.js';
 import type { ColorFormat } from '../TokenTypes/Color/types.js';
+import type { GradientStop } from '../TokenTypes/Gradient.js';
+import { GradientList, LinearGradient, RadialGradient } from '../TokenTypes/Gradient.js';
+import { isRefString } from '../TokenTypes/ref-guard.js';
 import type { AuditIssue } from './Plugin.js';
 import { Plugin } from './Plugin.js';
 
 type ColorTransformPluginOptions = { type?: ColorFormat } & Record<string, unknown>;
 
 /**
- * Normalizes colors
+ * Normalizes colors to a single format — including colors nested inside
+ * composite tokens (box shadows, borders, gradients), not just standalone
+ * `color` tokens. This keeps a shadow's color in the same space as the color
+ * tokens rather than falling through to the default serialization.
  */
 export class ColorTransformPlugin extends Plugin<ColorTransformPluginOptions> {
   outputType: RegExp = /.*/;
 
-  tokenType: string = 'color';
+  // Match every token type: colors can live inside shadows, borders, gradients,
+  // etc., so we can't gate on `type === 'color'`. `#transformValue` no-ops on
+  // any value that carries no color.
+  tokenType: RegExp = /.*/;
 
   override readonly runAfter: string[] = ['AlphaMultiplyPlugin'];
 
@@ -21,19 +32,116 @@ export class ColorTransformPlugin extends Plugin<ColorTransformPluginOptions> {
     super(options);
   }
 
-  override transform(token: Token): Token {
+  // Re-base a single color into the target space. A `{ref}` string (an
+  // unresolved per-field reference) passes through untouched.
+  #reColor(color: Color | string): Color | string {
     const { type } = this.options;
 
-    // Skip unresolved references — they'll be resolved later
-    if (
-      typeof token.value === 'string' &&
-      token.value.startsWith('{') &&
-      token.value.endsWith('}')
-    ) {
+    if (typeof color === 'string' || !type) {
+      return color;
+    }
+
+    // Round-trip through the target format so the stored color's native space
+    // becomes `type` — the composite serializers then emit it in that space.
+    return new Color(color.toString(type));
+  }
+
+  #reStop(stop: GradientStop): GradientStop {
+    return { ...stop, color: this.#reColor(stop.color) as Color };
+  }
+
+  // Return `value` with every color it contains re-based to the target format.
+  // Values that carry no color are returned unchanged (referential identity),
+  // so the plugin is a no-op on dimensions, durations, etc.
+  #transformValue(value: unknown, tokenType: string): unknown {
+    const { type } = this.options;
+
+    if (value instanceof Color) {
+      // Standalone color token → normalized string (long-standing behavior).
+      return value.toString(type);
+    }
+
+    if (value instanceof BoxShadow) {
+      return value.with({ color: this.#reColor(value.color) });
+    }
+
+    if (value instanceof BoxShadowList) {
+      return value.map(s => s.with({ color: this.#reColor(s.color) }));
+    }
+
+    if (value instanceof Border) {
+      return value.with({ color: this.#reColor(value.color) });
+    }
+
+    if (value instanceof LinearGradient) {
+      return new LinearGradient(
+        value.angle,
+        value.stops.map(s => this.#reStop(s)),
+      );
+    }
+
+    if (value instanceof RadialGradient) {
+      return new RadialGradient(
+        { shape: value.shape, size: value.size, position: value.position },
+        value.stops.map(s => this.#reStop(s)),
+      );
+    }
+
+    if (value instanceof GradientList) {
+      return value.map(g => this.#transformValue(g, tokenType) as LinearGradient | RadialGradient);
+    }
+
+    // A bare color string only appears on a color-typed token; other string
+    // values (dimensions, durations, …) must be left alone.
+    if (typeof value === 'string' && !isRefString(value) && tokenType === 'color') {
+      return new Color(value).toString(type);
+    }
+
+    return value;
+  }
+
+  override transform(token: Token): Token {
+    // Skip whole-value references — they resolve later.
+    if (typeof token.value === 'string' && isRefString(token.value)) {
       return token;
     }
 
-    return { ...token, value: new Color(token.value as string | Color).toString(type) };
+    const value = this.#transformValue(token.value, token.type);
+
+    return value === token.value ? token : { ...token, value: value as Token['value'] };
+  }
+
+  // Collect every concrete color a token contains, for alpha-loss auditing.
+  #collectColors(value: unknown, tokenType: string): Color[] {
+    if (value instanceof Color) {
+      return [value];
+    }
+
+    if (value instanceof BoxShadow || value instanceof Border) {
+      return value.color instanceof Color ? [value.color] : [];
+    }
+
+    if (value instanceof BoxShadowList) {
+      return value.layers.flatMap(s => (s.color instanceof Color ? [s.color] : []));
+    }
+
+    if (value instanceof LinearGradient || value instanceof RadialGradient) {
+      return value.stops.flatMap(s => (s.color instanceof Color ? [s.color] : []));
+    }
+
+    if (value instanceof GradientList) {
+      return value.layers.flatMap(g => this.#collectColors(g, tokenType));
+    }
+
+    if (typeof value === 'string' && !isRefString(value) && tokenType === 'color') {
+      try {
+        return [new Color(value)];
+      } catch {
+        return [];
+      }
+    }
+
+    return [];
   }
 
   override audit(tokens: Token[]): AuditIssue[] {
@@ -43,27 +151,19 @@ export class ColorTransformPlugin extends Plugin<ColorTransformPluginOptions> {
       return [];
     }
 
-    return tokens
-      .filter(t => t.type === this.tokenType)
-      .flatMap(t => {
-        // Skip unresolved references
-        if (typeof t.value === 'string' && t.value.startsWith('{') && t.value.endsWith('}')) {
-          return [];
-        }
-
-        const color = new Color(t.value as string | Color);
-
-        if (color.alpha < 1) {
-          return [
-            {
-              severity: 'warning' as const,
-              token: t.name,
-              message: `Color has alpha ${color.alpha} but output format "${type}" discards the alpha channel`,
-            },
-          ];
-        }
-
+    return tokens.flatMap(t => {
+      // Skip unresolved whole-value references
+      if (typeof t.value === 'string' && isRefString(t.value)) {
         return [];
-      });
+      }
+
+      return this.#collectColors(t.value, t.type)
+        .filter(color => color.alpha < 1)
+        .map(color => ({
+          severity: 'warning' as const,
+          token: t.name,
+          message: `Color has alpha ${color.alpha} but output format "${type}" discards the alpha channel`,
+        }));
+    });
   }
 }

--- a/src/TokenTypes/BoxShadow.test.ts
+++ b/src/TokenTypes/BoxShadow.test.ts
@@ -227,6 +227,11 @@ describe('BoxShadow', () => {
     expect(str).toContain('rgba');
   });
 
+  it('toString() preserves an oklch-authored shadow color', () => {
+    const s = new BoxShadow('0 2px 8px oklch(0.7 0.15 200 / 0.5)');
+    expect(s.toString()).toBe('0 2px 8px oklch(0.7 0.15 200 / 0.5)');
+  });
+
   it('toString() omits blur and spread when both zero', () => {
     const s = new BoxShadow(0, 0, 0, 0, '#000');
     const str = s.toString();

--- a/src/TokenTypes/BoxShadow.ts
+++ b/src/TokenTypes/BoxShadow.ts
@@ -1,10 +1,36 @@
 import { splitTopLevel } from '../string-utils.js';
 import { Color } from './Color/index.js';
-import { assertNotRef } from './ref-guard.js';
+import type { RefFields } from './ref-guard.js';
+import { assertNotRef, isRefString } from './ref-guard.js';
+
+// Coerce a color field. A `{ref}` string passes through untouched — references
+// are resolved later by `resolve.ts` (which rebuilds the wrapper via the
+// RefFields protocol), then the resolved concrete color flows back through here.
+const toColor = (value: Color | string | undefined): Color | string => {
+  if (value === undefined) {
+    return new Color(0, 0, 0);
+  }
+
+  if (value instanceof Color || isRefString(value)) {
+    return value;
+  }
+
+  return new Color(value);
+};
 
 const lengthRe = /^(-?\d+(?:\.\d+)?)(px|rem|em)?/;
 
 const fmtLength = (v: number): string => (v === 0 ? '0' : `${v}px`);
+
+// The leftover token after the numeric lengths is the color: a `{ref}` string
+// (kept for per-field resolution), a parsed Color, or black when absent.
+const parseShorthandColor = (s: string): Color | string => {
+  if (s.length === 0) {
+    return new Color(0, 0, 0);
+  }
+
+  return isRefString(s) ? s : new Color(s);
+};
 
 const stripKeyword = (str: string, keyword: string): string => {
   if (str.startsWith(`${keyword} `)) {
@@ -25,7 +51,7 @@ const parse = (
   offsetY: number;
   blur: number;
   spread: number;
-  color: Color;
+  color: Color | string;
   inset: boolean;
 } => {
   const trimmed = str.trim();
@@ -47,7 +73,9 @@ const parse = (
     s = s.slice(m[0].length).trim();
   }
 
-  const color = s.length > 0 ? new Color(s) : new Color(0, 0, 0);
+  // A `{ref}` color in the shorthand (e.g. "0 2px 8px {color.ink}") is kept as a
+  // reference string rather than erroring; it resolves per-field later.
+  const color = parseShorthandColor(s);
 
   return {
     offsetX: nums[0] ?? 0,
@@ -68,14 +96,14 @@ export type BoxShadowOptions = {
   inset?: boolean;
 };
 
-export class BoxShadow {
+export class BoxShadow implements RefFields {
   /** @internal brand — do not use directly; see `isFirstClassValue()` */
   readonly __teikn_fcv__: true = true;
   readonly #offsetX: number;
   readonly #offsetY: number;
   readonly #blur: number;
   readonly #spread: number;
-  readonly #color: Color;
+  readonly #color: Color | string;
   readonly #inset: boolean;
 
   constructor(
@@ -120,12 +148,11 @@ export class BoxShadow {
     }
 
     if (typeof first === 'object') {
-      const c = first.color;
       this.#offsetX = first.offsetX ?? 0;
       this.#offsetY = first.offsetY ?? 0;
       this.#blur = first.blur ?? 0;
       this.#spread = first.spread ?? 0;
-      this.#color = typeof c === 'string' ? new Color(c) : (c ?? new Color(0, 0, 0));
+      this.#color = toColor(first.color);
       this.#inset = first.inset ?? false;
 
       return;
@@ -135,7 +162,7 @@ export class BoxShadow {
     this.#offsetY = offsetY ?? 0;
     this.#blur = blur ?? 0;
     this.#spread = spread ?? 0;
-    this.#color = typeof color === 'string' ? new Color(color) : (color ?? new Color(0, 0, 0));
+    this.#color = toColor(color);
     this.#inset = inset ?? false;
   }
 
@@ -151,11 +178,33 @@ export class BoxShadow {
   get spread(): number {
     return this.#spread;
   }
-  get color(): Color {
+  get color(): Color | string {
     return this.#color;
   }
   get inset(): boolean {
     return this.#inset;
+  }
+
+  // ─── Per-field reference protocol ────────────────────────────
+  // Lets a shadow hold `{ref}` strings in its fields (resolved per-field by
+  // `resolve.ts`) instead of erroring, mirroring Border / Typography.
+
+  /** @internal */
+  __teikn_fields__(): Record<string, unknown> {
+    return {
+      offsetX: this.#offsetX,
+      offsetY: this.#offsetY,
+      blur: this.#blur,
+      spread: this.#spread,
+      color: this.#color,
+      inset: this.#inset,
+    };
+  }
+
+  /** @internal */
+  // oxlint-disable-next-line class-methods-use-this -- protocol method, detected per-instance
+  __teikn_fromFields__(fields: Record<string, unknown>): BoxShadow {
+    return new BoxShadow(fields as BoxShadowOptions);
   }
 
   with(updates: BoxShadowOptions): BoxShadow {
@@ -203,7 +252,7 @@ export class BoxShadow {
       parts.push(fmtLength(this.#spread));
     }
 
-    parts.push(this.#color.toString());
+    parts.push(String(this.#color));
 
     return parts.join(' ');
   }
@@ -222,7 +271,7 @@ export class BoxShadow {
   }
 }
 
-export class BoxShadowList {
+export class BoxShadowList implements RefFields {
   /** @internal brand — do not use directly; see `isFirstClassValue()` */
   readonly __teikn_fcv__: true = true;
   readonly #layers: readonly BoxShadow[];
@@ -258,6 +307,21 @@ export class BoxShadowList {
 
   map(fn: (shadow: BoxShadow, index: number) => BoxShadow): BoxShadowList {
     return new BoxShadowList(this.#layers.map(fn));
+  }
+
+  // ─── Per-field reference protocol ────────────────────────────
+  // Each layer is itself a RefFields BoxShadow, so exposing the layers lets
+  // resolve.ts descend and resolve a per-layer `{ref}` color.
+
+  /** @internal */
+  __teikn_fields__(): Record<string, unknown> {
+    return { layers: [...this.#layers] };
+  }
+
+  /** @internal */
+  // oxlint-disable-next-line class-methods-use-this -- protocol method, detected per-instance
+  __teikn_fromFields__(fields: Record<string, unknown>): BoxShadowList {
+    return new BoxShadowList(fields.layers as BoxShadow[]);
   }
 
   toJSON(): string {

--- a/src/TokenTypes/Color/Color.ts
+++ b/src/TokenTypes/Color/Color.ts
@@ -133,6 +133,19 @@ const fmt = {
   },
 };
 
+// Maps each stored color space to the CSS format that round-trips it losslessly.
+// Used by `toString('native')` (and the formatless default) to preserve the
+// space a color was authored in rather than flattening everything to rgb.
+const NATIVE_FORMAT: Record<Space, ColorFormat> = {
+  rgb: 'rgb',
+  hsl: 'hsl',
+  xyz: 'xyz',
+  lab: 'lab',
+  lch: 'lch',
+  oklab: 'oklab',
+  oklch: 'oklch',
+};
+
 // sRGB linearization / delinearization helpers
 const linearize = (c: number): number => (c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4);
 
@@ -929,8 +942,15 @@ export class Color {
         return fmt.xyz(this.asXYZ());
       case 'xyza':
         return fmt.xyz(this.asXYZA());
-      default:
-        return this.#alpha === 1 ? fmt.rgb(this.asRGB()) : fmt.rgb(this.asRGBA());
+      case 'native':
+      default: {
+        // Serialize in whatever space the color was authored in, so oklch stays
+        // oklch, hex/rgb stays rgb, etc. Reading the native space is a cache hit
+        // (no conversion), so this is lossless apart from decimal rounding.
+        const base = NATIVE_FORMAT[this.#nativeSpace];
+
+        return this.toString(this.#alpha === 1 ? base : (`${base}a` as ColorFormat));
+      }
     }
   }
 }

--- a/src/TokenTypes/Color/color.test.ts
+++ b/src/TokenTypes/Color/color.test.ts
@@ -215,6 +215,30 @@ describe('Color tests', () => {
     expect(new Color('blue').toString('rgb')).toBe('rgb(0, 0, 255)');
   });
 
+  // ─── native-space default serialization ────────────────
+  // toString() with no format serializes in the color's authored space, so
+  // authored space survives to output instead of flattening to rgb.
+
+  test('formatless toString() preserves the authored oklch space', () => {
+    const c = new Color('oklch(0.7 0.15 200)');
+    expect(c.toString()).toBe('oklch(0.7 0.15 200)');
+    expect(c.toString('native')).toBe(c.toString());
+  });
+
+  test('formatless toString() preserves oklch alpha', () => {
+    expect(new Color('oklch(0.7 0.15 200 / 0.5)').toString()).toBe('oklch(0.7 0.15 200 / 0.5)');
+  });
+
+  test('formatless toString() keeps rgb-based colors as rgb', () => {
+    expect(new Color('#4682b4').toString()).toBe('rgb(70, 130, 180)');
+    expect(new Color('rgb(1, 2, 3)').toString()).toBe('rgb(1, 2, 3)');
+  });
+
+  test('native format still round-trips through an explicit format', () => {
+    // oklch authored, requested as rgb — explicit format overrides the native default.
+    expect(new Color('oklch(0.7 0.15 200)').toString('rgb')).toMatch(/^rgb\(/);
+  });
+
   test('Getting named colors works', () => {
     expect(new Color('#ffffff').toString('named')).toBe('white');
   });
@@ -290,11 +314,13 @@ describe('Color tests', () => {
   // ─── HSL mutation tests ──────────────────────────────────
 
   test('Setting Hue works', () => {
-    expect(new Color('green').setHue(200).toString()).toEqual('rgb(0, 85, 128)');
+    // HSL operations return an hsl-native color, so pin the assertion to rgb to
+    // test the operation math rather than the (native) default serialization.
+    expect(new Color('green').setHue(200).toString('rgb')).toEqual('rgb(0, 85, 128)');
   });
 
   test('Setting Saturation works', () => {
-    expect(new Color('green').setSaturation(0.5).toString()).toEqual('rgb(32, 96, 32)');
+    expect(new Color('green').setSaturation(0.5).toString('rgb')).toEqual('rgb(32, 96, 32)');
   });
 
   test('Setting lightness works', () => {
@@ -312,7 +338,7 @@ describe('Color tests', () => {
   });
 
   test('test lightening green', () => {
-    expect(new Color('green').lighten(0.5).toString()).toBe('rgb(0, 192, 0)');
+    expect(new Color('green').lighten(0.5).toString('rgb')).toBe('rgb(0, 192, 0)');
   });
 
   test('Darkening colors works', () => {

--- a/src/TokenTypes/Color/types.ts
+++ b/src/TokenTypes/Color/types.ts
@@ -50,4 +50,7 @@ export type ColorFormat =
   | 'oklch'
   | 'oklcha'
   | 'named'
-  | 'xkcd';
+  | 'xkcd'
+  // Serialize in the color's native (authored) space — lossless, no gamut clip.
+  // This is what `toString()` uses when no format is passed.
+  | 'native';

--- a/src/TokenTypes/Gradient.test.ts
+++ b/src/TokenTypes/Gradient.test.ts
@@ -369,3 +369,39 @@ describe('GradientList', () => {
     expect(list.length).toBe(2);
   });
 });
+
+describe('per-field {ref} colors (RefFields protocol)', () => {
+  it('LinearGradient holds a {ref} stop color instead of throwing', () => {
+    const g = new LinearGradient(180, [
+      ['{color.brand}', '0%'],
+      ['#000', '100%'],
+    ]);
+    expect(g.stops[0]!.color).toBe('{color.brand}');
+    expect(g.toString()).toBe('linear-gradient(to bottom, {color.brand} 0%, rgb(0, 0, 0) 100%)');
+  });
+
+  it('accepts a {ref} via addStop and a bare string stop', () => {
+    const g = new LinearGradient(90, ['#fff']).addStop('{color.brand}', '50%');
+    expect(g.stops[1]!.color).toBe('{color.brand}');
+  });
+
+  it('RadialGradient holds a {ref} stop color', () => {
+    const g = new RadialGradient({ shape: 'circle' }, [
+      ['{color.brand}', '0%'],
+      ['#000', '100%'],
+    ]);
+    expect(g.stops[0]!.color).toBe('{color.brand}');
+    expect(g.toString()).toContain('{color.brand} 0%');
+  });
+
+  it('exposes stops through the RefFields protocol and rebuilds from them', () => {
+    const g = new LinearGradient(180, [
+      ['{color.brand}', '0%'],
+      ['#000', '100%'],
+    ]);
+    const fields = g.__teikn_fields__();
+    expect(Array.isArray(fields.stops)).toBe(true);
+    const rebuilt = g.__teikn_fromFields__(fields);
+    expect(rebuilt.toString()).toBe(g.toString());
+  });
+});

--- a/src/TokenTypes/Gradient.ts
+++ b/src/TokenTypes/Gradient.ts
@@ -1,18 +1,26 @@
 import { splitTopLevel } from '../string-utils.js';
 import { Color } from './Color/index.js';
-import { assertNotRef } from './ref-guard.js';
+import type { RefFields } from './ref-guard.js';
+import { assertNotRef, isRefString } from './ref-guard.js';
 
 // ─── Shared types ─────────────────────────────────────────────
 
-export type GradientStop = { color: Color; position?: string };
+// A stop color may be a `{ref}` string (resolved per-field by resolve.ts) as
+// well as a concrete Color.
+export type GradientStop = { color: Color | string; position?: string };
 
 export type StopInput = GradientStop | Color | string | [color: Color | string, position: string];
+
+// Coerce a stop color: a `{ref}` passes through untouched, everything else is
+// parsed into a Color.
+const toStopColor = (value: Color | string): Color | string =>
+  value instanceof Color || isRefString(value) ? value : new Color(value);
 
 // ─── Helpers ──────────────────────────────────────────────────
 
 const normalizeStop = (input: StopInput): GradientStop => {
   if (typeof input === 'string') {
-    return { color: new Color(input) };
+    return { color: toStopColor(input) };
   }
 
   if (input instanceof Color) {
@@ -20,9 +28,7 @@ const normalizeStop = (input: StopInput): GradientStop => {
   }
 
   if (Array.isArray(input)) {
-    const color = input[0] instanceof Color ? input[0] : new Color(input[0]);
-
-    return { color, position: input[1] };
+    return { color: toStopColor(input[0]), position: input[1] };
   }
 
   return input;
@@ -50,15 +56,17 @@ const parseStop = (str: string): GradientStop => {
     const after = s.slice(lastSpace + 1).trim();
 
     if (/^\d+(\.\d+)?(%|px|rem|em|vw|vh)$/.test(after)) {
-      return { color: new Color(s.slice(0, lastSpace).trim()), position: after };
+      return { color: toStopColor(s.slice(0, lastSpace).trim()), position: after };
     }
   }
 
-  return { color: new Color(s) };
+  return { color: toStopColor(s) };
 };
 
-const stopToCSS = (stop: GradientStop): string => {
-  const c = stop.color.toString();
+// Render one stop, delegating color rendering so ref-aware serializers can
+// substitute `var(--…)` while `toString()` uses the plain string form.
+const renderStop = (stop: GradientStop, renderColor: (color: Color | string) => string): string => {
+  const c = renderColor(stop.color);
 
   return stop.position ? `${c} ${stop.position}` : c;
 };
@@ -122,7 +130,7 @@ const linearRe = /^linear-gradient\(([\s\S]+)\)$/i;
 
 export type LinearGradientInput = { angle: number; stops: StopInput[] };
 
-export class LinearGradient {
+export class LinearGradient implements RefFields {
   /** @internal brand — do not use directly; see `isFirstClassValue()` */
   readonly __teikn_fcv__: true = true;
   readonly #angle: number;
@@ -208,10 +216,25 @@ export class LinearGradient {
   }
 
   addStop(color: Color | string, position?: string): LinearGradient {
-    const c = color instanceof Color ? color : new Color(color);
+    const c = toStopColor(color);
     const stop: GradientStop = position ? { color: c, position } : { color: c };
 
     return new LinearGradient(this.#angle, [...this.#stops, stop]);
+  }
+
+  // ─── Per-field reference protocol ────────────────────────────
+  // Lets a stop hold a `{ref}` color (resolved per-field by resolve.ts) instead
+  // of erroring, mirroring Border / BoxShadow.
+
+  /** @internal */
+  __teikn_fields__(): Record<string, unknown> {
+    return { angle: this.#angle, stops: [...this.#stops] };
+  }
+
+  /** @internal */
+  // oxlint-disable-next-line class-methods-use-this -- protocol method, detected per-instance
+  __teikn_fromFields__(fields: Record<string, unknown>): LinearGradient {
+    return new LinearGradient(fields.angle as number, fields.stops as StopInput[]);
   }
 
   toJSON(): string {
@@ -219,11 +242,20 @@ export class LinearGradient {
   }
 
   toString(): string {
+    return this.toCSSWith(String);
+  }
+
+  /**
+   * Serialize with a custom color renderer, so ref-aware generators can emit
+   * `var(--…)` for stop colors that reference a token. `toString()` passes
+   * `String`, which renders concrete colors and inlines any `{ref}` verbatim.
+   */
+  toCSSWith(renderColor: (color: Color | string) => string): string {
     if (this.#stops.length === 0) {
       throw new Error('LinearGradient requires at least one color stop');
     }
 
-    const stopsStr = this.#stops.map(stopToCSS).join(', ');
+    const stopsStr = this.#stops.map(s => renderStop(s, renderColor)).join(', ');
     const kw = angleKeywords[this.#angle];
     const dir = kw ?? `${this.#angle}deg`;
 
@@ -251,7 +283,7 @@ const radialRe = /^radial-gradient\(([\s\S]+)\)$/i;
 const isShapeSpec = (str: string): boolean =>
   /^(circle|ellipse|closest|farthest)/i.test(str) || /\bat\s/i.test(str);
 
-export class RadialGradient {
+export class RadialGradient implements RefFields {
   /** @internal brand — do not use directly; see `isFirstClassValue()` */
   readonly __teikn_fcv__: true = true;
   readonly #shape: RadialShape;
@@ -354,7 +386,7 @@ export class RadialGradient {
   }
 
   addStop(color: Color | string, position?: string): RadialGradient {
-    const c = color instanceof Color ? color : new Color(color);
+    const c = toStopColor(color);
     const stop: GradientStop = position ? { color: c, position } : { color: c };
 
     return new RadialGradient({ shape: this.#shape, size: this.#size, position: this.#position }, [
@@ -374,12 +406,42 @@ export class RadialGradient {
     );
   }
 
+  // ─── Per-field reference protocol ────────────────────────────
+
+  /** @internal */
+  __teikn_fields__(): Record<string, unknown> {
+    return {
+      shape: this.#shape,
+      size: this.#size,
+      position: this.#position,
+      stops: [...this.#stops],
+    };
+  }
+
+  /** @internal */
+  // oxlint-disable-next-line class-methods-use-this -- protocol method, detected per-instance
+  __teikn_fromFields__(fields: Record<string, unknown>): RadialGradient {
+    return new RadialGradient(
+      {
+        shape: fields.shape as RadialShape,
+        size: fields.size as RadialSize,
+        position: fields.position as string,
+      },
+      fields.stops as StopInput[],
+    );
+  }
+
   toJSON(): string {
     return this.toString();
   }
 
   toString(): string {
-    const stopsStr = this.#stops.map(stopToCSS).join(', ');
+    return this.toCSSWith(String);
+  }
+
+  /** See {@link LinearGradient.toCSSWith}. */
+  toCSSWith(renderColor: (color: Color | string) => string): string {
+    const stopsStr = this.#stops.map(s => renderStop(s, renderColor)).join(', ');
     const shapeParts: string[] = [];
 
     if (this.#shape !== 'ellipse' || this.#size !== 'farthest-corner') {
@@ -434,7 +496,7 @@ const parseGradient = (str: string): AnyGradient => {
   throw new Error(`Unknown gradient type: "${s}"`);
 };
 
-export class GradientList {
+export class GradientList implements RefFields {
   /** @internal brand — do not use directly; see `isFirstClassValue()` */
   readonly __teikn_fcv__: true = true;
   readonly #layers: readonly AnyGradient[];
@@ -472,12 +534,32 @@ export class GradientList {
     return new GradientList(this.#layers.map(fn));
   }
 
+  // ─── Per-field reference protocol ────────────────────────────
+  // Each layer is itself a RefFields gradient, so exposing the layers lets
+  // resolve.ts descend and resolve per-stop `{ref}` colors.
+
+  /** @internal */
+  __teikn_fields__(): Record<string, unknown> {
+    return { layers: [...this.#layers] };
+  }
+
+  /** @internal */
+  // oxlint-disable-next-line class-methods-use-this -- protocol method, detected per-instance
+  __teikn_fromFields__(fields: Record<string, unknown>): GradientList {
+    return new GradientList(fields.layers as AnyGradient[]);
+  }
+
   toJSON(): string {
     return this.toString();
   }
 
   toString(): string {
     return this.#layers.map(g => g.toString()).join(', ');
+  }
+
+  /** See {@link LinearGradient.toCSSWith}. */
+  toCSSWith(renderColor: (color: Color | string) => string): string {
+    return this.#layers.map(g => g.toCSSWith(renderColor)).join(', ');
   }
 
   static from(value: GradientList | string | (LinearGradient | RadialGradient)[]): GradientList {

--- a/src/dtcg/values.ts
+++ b/src/dtcg/values.ts
@@ -235,15 +235,25 @@ const stringDurationToDtcg = (str: string): DtcgDurationValue | string => {
 
 const cubicBezierToDtcg = (cb: CubicBezier): DtcgCubicBezierValue => [cb.x1, cb.y1, cb.x2, cb.y2];
 
-const gradientStopToDtcg = (stop: { color: Color; position?: string }): DtcgGradientStop => {
+const gradientStopToDtcg = (
+  stop: { color: Color | string; position?: string },
+  refMap?: DtcgRefMap,
+): DtcgGradientStop => {
   const posStr = stop.position ?? '0%';
   const posNum = parseFloat(posStr) / 100;
 
-  return { color: colorToDtcg(stop.color), position: isNaN(posNum) ? 0 : posNum };
+  // Handles an identity ref (shared Color → `{alias}`), a leftover `{ref}`
+  // string, or a concrete color — same as shadow/border colors.
+  return {
+    color: colorFieldToDtcg(stop.color, refMap) as DtcgGradientStop['color'],
+    position: isNaN(posNum) ? 0 : posNum,
+  };
 };
 
-const gradientToDtcg = (gradient: LinearGradient | RadialGradient): DtcgGradientValue =>
-  [...gradient.stops].map(gradientStopToDtcg);
+const gradientToDtcg = (
+  gradient: LinearGradient | RadialGradient,
+  refMap?: DtcgRefMap,
+): DtcgGradientValue => [...gradient.stops].map(stop => gradientStopToDtcg(stop, refMap));
 
 // Convert a single teikn value (instanceof-based) to its Dtcg representation.
 // Returns null when the value is not a recognized first-class type.
@@ -265,11 +275,11 @@ const convertSingleValue = (value: unknown, refMap?: DtcgRefMap): DtcgValue | nu
   }
 
   if (value instanceof LinearGradient || value instanceof RadialGradient) {
-    return gradientToDtcg(value);
+    return gradientToDtcg(value, refMap);
   }
 
   if (value instanceof GradientList) {
-    return value.layers.map(g => gradientToDtcg(g)) as unknown as DtcgValue;
+    return value.layers.map(g => gradientToDtcg(g, refMap)) as unknown as DtcgValue;
   }
 
   if (value instanceof Dimension) {
@@ -311,12 +321,10 @@ const transitionToDtcg = (t: Transition, refMap?: DtcgRefMap): Record<string, un
 };
 
 const shadowToDtcgWithRefs = (shadow: BoxShadow, refMap?: DtcgRefMap): DtcgShadowValue => {
-  const colorRef = refMap?.get(shadow.color);
-
   return {
-    color: colorRef
-      ? (dtcgAlias(colorRef) as unknown as DtcgColorValue)
-      : colorToDtcg(shadow.color),
+    // Handles an identity ref (shared Color → `{alias}`), a leftover `{ref}`
+    // string, or a concrete color — mirroring how borders serialize their color.
+    color: colorFieldToDtcg(shadow.color, refMap) as DtcgColorValue,
     offsetX: { value: shadow.offsetX, unit: 'px' },
     offsetY: { value: shadow.offsetY, unit: 'px' },
     blur: { value: shadow.blur, unit: 'px' },

--- a/src/reference-stress.test.ts
+++ b/src/reference-stress.test.ts
@@ -118,10 +118,12 @@ describe('reference stress', () => {
     );
   });
 
-  test('(8) BoxShadow with a ref-string color is rejected via Color', () => {
-    expect(
-      () => new BoxShadow({ offsetX: 0, offsetY: 2, blur: 8, spread: 0, color: '{accent}' }),
-    ).toThrow(/Color cannot be constructed from a reference string/);
+  test('(8) BoxShadow tolerates a ref-string color and re-emits it (RefFields)', () => {
+    // Unlike a leaf Color, BoxShadow holds a per-field `{ref}` (resolved later by
+    // resolve.ts) rather than erroring — mirroring Border/Typography.
+    const shadow = new BoxShadow({ offsetX: 0, offsetY: 2, blur: 8, spread: 0, color: '{accent}' });
+    expect(shadow.color).toBe('{accent}');
+    expect(shadow.toString()).toBe('0 2px 8px {accent}');
   });
 
   // ── Scenario 9: ref points at a composite value ───────────────

--- a/src/resolve.test.ts
+++ b/src/resolve.test.ts
@@ -168,11 +168,34 @@ describe('resolveReferences', () => {
     expect(result[0]!.value).toBe(cb);
   });
 
-  test('BoxShadow values are NOT destructured as composites', () => {
-    const shadow = new BoxShadow(0, 2, 8, 0, new Color(0, 0, 0));
+  test('BoxShadow resolves per-field refs but stays a BoxShadow (not a POJO)', () => {
+    // BoxShadow implements the RefFields protocol (like Border/Typography), so a
+    // ref-free shadow is rebuilt into an equal BoxShadow rather than exploded
+    // into a plain object. The nested Color instance is preserved by identity.
+    const color = new Color(0, 0, 0);
+    const shadow = new BoxShadow(0, 2, 8, 0, color);
     const tokens: Token[] = [{ name: 'shadow', type: 'shadow', value: shadow }];
     const result = resolveReferences(tokens);
-    expect(result[0]!.value).toBe(shadow);
+    expect(result[0]!.value).toBeInstanceOf(BoxShadow);
+    expect((result[0]!.value as BoxShadow).color).toBe(color);
+    expect(result[0]!.value!.toString()).toBe(shadow.toString());
+  });
+
+  test('a BoxShadow color `{ref}` resolves to the referenced color instance', () => {
+    const line = new Color(70, 130, 180);
+    const tokens: Token[] = [
+      { name: 'line', type: 'color', value: line },
+      {
+        name: 'shadow',
+        type: 'shadow',
+        value: new BoxShadow({ offsetY: 2, blur: 8, color: '{line}' }),
+      },
+    ];
+    const result = resolveReferences(tokens);
+    const resolved = result[1]!.value as BoxShadow;
+    expect(resolved).toBeInstanceOf(BoxShadow);
+    // resolved to the `line` token's exact instance → serializers can emit var(--line)
+    expect(resolved.color).toBe(line);
   });
 
   test('Transition values are NOT destructured as composites', () => {
@@ -182,24 +205,50 @@ describe('resolveReferences', () => {
     expect(result[0]!.value).toBe(t);
   });
 
-  test('LinearGradient values are NOT destructured as composites', () => {
+  test('LinearGradient resolves per-stop refs but stays a LinearGradient', () => {
+    // Gradients implement the RefFields protocol, so a ref-free gradient is
+    // rebuilt into an equal instance rather than exploded into a plain object.
+    const c0 = new Color(255, 0, 0);
     const lg = new LinearGradient(180, [
-      [new Color(255, 0, 0), '0%'],
+      [c0, '0%'],
       [new Color(0, 0, 255), '100%'],
     ]);
     const tokens: Token[] = [{ name: 'grad', type: 'gradient', value: lg }];
     const result = resolveReferences(tokens);
-    expect(result[0]!.value).toBe(lg);
+    expect(result[0]!.value).toBeInstanceOf(LinearGradient);
+    expect(result[0]!.value!.toString()).toBe(lg.toString());
+    // literal-only stops keep their color instances
+    expect((result[0]!.value as LinearGradient).stops[0]!.color).toBe(c0);
   });
 
-  test('RadialGradient values are NOT destructured as composites', () => {
+  test('a LinearGradient stop `{ref}` resolves to the referenced color instance', () => {
+    const brand = new Color(70, 130, 180);
+    const tokens: Token[] = [
+      { name: 'brand', type: 'color', value: brand },
+      {
+        name: 'grad',
+        type: 'gradient',
+        value: new LinearGradient(180, [
+          ['{brand}', '0%'],
+          [new Color(0, 0, 0), '100%'],
+        ]),
+      },
+    ];
+    const result = resolveReferences(tokens);
+    const resolved = result[1]!.value as LinearGradient;
+    expect(resolved).toBeInstanceOf(LinearGradient);
+    expect(resolved.stops[0]!.color).toBe(brand);
+  });
+
+  test('RadialGradient resolves per-stop refs but stays a RadialGradient', () => {
     const rg = new RadialGradient({ shape: 'circle' }, [
       new Color(255, 0, 0),
       new Color(0, 0, 255),
     ]);
     const tokens: Token[] = [{ name: 'radGrad', type: 'gradient', value: rg }];
     const result = resolveReferences(tokens);
-    expect(result[0]!.value).toBe(rg);
+    expect(result[0]!.value).toBeInstanceOf(RadialGradient);
+    expect(result[0]!.value!.toString()).toBe(rg.toString());
   });
 
   test('Color values are NOT destructured as composites', () => {
@@ -275,14 +324,35 @@ describe('resolveReferences', () => {
     expect(result[0]!.modes).toBeUndefined();
   });
 
-  test('BoxShadowList values are NOT destructured as composites', () => {
+  test('BoxShadowList resolves per-layer refs but stays a BoxShadowList', () => {
+    // Implements RefFields, so a ref-free list is rebuilt into an equal instance.
     const list = new BoxShadowList([
       new BoxShadow(0, 1, 2, 0, '#000'),
       new BoxShadow(0, 4, 8, 0, '#000'),
     ]);
     const tokens: Token[] = [{ name: 'shadow', type: 'shadow', value: list }];
     const result = resolveReferences(tokens);
-    expect(result[0]!.value).toBe(list);
+    expect(result[0]!.value).toBeInstanceOf(BoxShadowList);
+    expect(result[0]!.value!.toString()).toBe(list.toString());
+  });
+
+  test('a BoxShadowList layer `{ref}` resolves to the referenced color instance', () => {
+    const ink = new Color(0, 0, 0);
+    const tokens: Token[] = [
+      { name: 'ink', type: 'color', value: ink },
+      {
+        name: 'elevated',
+        type: 'shadow',
+        value: new BoxShadowList([
+          new BoxShadow({ offsetY: 2, blur: 4, color: '{ink}' }),
+          new BoxShadow({ offsetY: 8, blur: 16, color: '#333' }),
+        ]),
+      },
+    ];
+    const result = resolveReferences(tokens);
+    const resolved = result[1]!.value as BoxShadowList;
+    expect(resolved).toBeInstanceOf(BoxShadowList);
+    expect(resolved.layers[0]!.color).toBe(ink);
   });
 
   // ─── Ref edge cases ────────────────────────────────────────

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -23,6 +23,24 @@ type ResolveModesArgs = { modes: ModeValues; tokenName: string };
  */
 const createResolver = (tokenMap: Map<string, Token>, tokenKeys: KeyAliasIndex) => {
   const resolveValue = ({ value, seen, currentName }: ResolveArgs): unknown => {
+    // Arrays (e.g. gradient stops exposed via RefFields) are resolved
+    // element-wise. Identity is preserved when nothing inside changed so the
+    // caller's short-circuit can skip cloning literal-only values.
+    if (Array.isArray(value)) {
+      let changed = false;
+      const resolved = value.map(item => {
+        const next = resolveValue({ value: item, seen, currentName });
+
+        if (next !== item) {
+          changed = true;
+        }
+
+        return next;
+      });
+
+      return changed ? resolved : value;
+    }
+
     if (isCompositeValue(value)) {
       // Use a null-prototype object so a field literally named `__proto__`
       // (possible from JSON-parsed input) is stored as a data property

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -146,11 +146,13 @@ const validateValue = (
     }
   }
 
-  // First-class wrappers (Typography, Border) carry their fields behind private
-  // state; inspect them through the RefFields protocol so per-field references
-  // get the same unresolved/ambiguous checks as plain composites.
+  // First-class wrappers (Typography, Border, BoxShadow, Gradient) carry their
+  // fields behind private state; inspect them through the RefFields protocol so
+  // per-field references get the same unresolved/ambiguous checks as plain
+  // composites. Recurse into arrays and nested wrappers so refs buried inside a
+  // gradient's stops (an array of `{ color, position }`) are still caught.
   if (hasRefFields(value)) {
-    for (const [field, fieldValue] of Object.entries(value.__teikn_fields__())) {
+    const checkFieldRefs = (field: string, fieldValue: unknown): void => {
       if (isRef(fieldValue)) {
         checkRef(
           fieldValue,
@@ -160,7 +162,33 @@ const validateValue = (
           label,
           issue,
         );
+
+        return;
       }
+
+      if (Array.isArray(fieldValue)) {
+        fieldValue.forEach(item => checkFieldRefs(field, item));
+
+        return;
+      }
+
+      if (hasRefFields(fieldValue)) {
+        for (const [k, v] of Object.entries(fieldValue.__teikn_fields__())) {
+          checkFieldRefs(`${field}.${k}`, v);
+        }
+
+        return;
+      }
+
+      if (isComposite(fieldValue)) {
+        for (const [k, v] of Object.entries(fieldValue as CompositeValue)) {
+          checkFieldRefs(`${field}.${k}`, v);
+        }
+      }
+    };
+
+    for (const [field, fieldValue] of Object.entries(value.__teikn_fields__())) {
+      checkFieldRefs(field, fieldValue);
     }
   }
 };
@@ -269,6 +297,10 @@ export const validate = (tokens: Token[]): ValidationResult => {
     originName: string,
     visited: Set<string>,
   ): boolean => {
+    if (Array.isArray(value)) {
+      return value.some(item => checkCircularValue(item, originName, visited));
+    }
+
     if (isComposite(value)) {
       for (const fieldValue of Object.values(value as CompositeValue)) {
         if (checkCircularValue(fieldValue, originName, visited)) {


### PR DESCRIPTION
## Summary

Started from a report that authoring an ink/box-shadow color in `oklch` came out as `rgb`. Fixing that surfaced a chain of related gaps, all closed here.

### 1. `Color.toString()` serializes in the authored space (⚠️ breaking)
Formatless `toString()` now emits the color's **native** space (`oklch` stays `oklch`, `hsl` stays `hsl`, hex/rgb/named stay `rgb`) instead of always flattening to `rgb`. Reading the native space is a cache hit, so it's lossless apart from decimal rounding — no round trip through 8-bit, gamut-clipped `rgb`. This is what box-shadow and other composite serializers call, so an oklch-authored shadow color now emits oklch. Adds a `'native'` `ColorFormat` naming the default explicitly.

- **Migration:** restore the old output with `toString('rgb')` or `ColorTransformPlugin({ type: 'rgb' })`.
- Color operations (`lighten`/`setHue`) return a color in their working space, so their formatless output is now that space.

### 2. Colors are normalized and referenceable everywhere they appear
- **`ColorTransformPlugin` re-bases colors nested in composites** (shadows, borders, gradient stops), not just standalone `color` tokens — so `{ type: 'oklch' }` no longer leaves a shadow at `rgb` while color tokens become `oklch`. Notational formats (hex/named/forced-alpha) render nested colors in the space's canonical notation; standalone tokens keep exact notation.
- **`BoxShadow`, `BoxShadowList`, `LinearGradient`, `RadialGradient`, `GradientList` implement `RefFields`** — a per-field `{ref}` color resolves instead of throwing: `var(--…)` in CSS, `$var` in SCSS, a `{alias}` in DTCG, and `validate()` flags unresolved refs. `resolve()`/`validate()` now recurse into arrays so refs buried in gradient stops / shadow layers resolve.

## Testing
Adds a parametrized **color-ref matrix** — every ref-carrying type × { author, CSS, SCSS, DTCG, validate, plugin re-base, mode value } — plus circular-through-array and hex-notation-caveat cases.

- Full suite: **2153 pass, 0 fail**
- `tsc` clean (pre-existing storybook JSX errors unchanged), lint clean, format clean

## Notes
- Docs updated: `CHANGELOG.md` (Unreleased) and `README.md`.
- No version bump — left for a separate release PR per the repo's convention.