### PR TITLE
Aliased top-level refs + explicit-intent PerceptualDistancePlugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- **`ref(name, { link: true })` emits a live alias instead of flattening.** By default a top-level
+  `ref()` is baked into its resolved value; passing `{ link: true }` makes reference-aware
+  generators emit an alias to the target — `var(--…)` in CssVars, `$…` in ScssVars, and a DTCG
+  `{token}` alias in Dtcg — so a runtime override of the target flows through (the "styling hooks"
+  pattern, and small theme layers that move a shared ramp tier). Value formats (Json, JavaScript,
+  TypeScript) still flatten. Aliasing is orthogonal to auditing: `resolveReferences()` continues to
+  yield the concrete value, and a linked reference to a missing token is still a build-time
+  validation error. The second argument to `ref()` now accepts either a usage string (unchanged) or
+  an options object `{ usage?, link? }`.
+
+### Changed
+
+- **`PerceptualDistancePlugin` no longer manufactures author intent.** It previously compared every
+  color pair within each `token.group` and warned below a ΔE threshold by default, flagging ramp
+  steps and aliases that are _meant_ to be close. It now takes intent explicitly — mirroring
+  `ContrastValidatorPlugin`'s `pairs`:
+  - `sets: [[…]]` — declare peer sets that must be mutually distinguishable; the plugin measures
+    within each and ignores everything else. (Recommended.)
+  - `all: true` — opt in to the old all-pairs gating explicitly.
+  - `report: true` — emit the pairwise ΔE as non-gating `info` findings (most-similar first), with
+    no pass/fail.
+  - With none of these, the plugin compares nothing and emits a single advisory instead of gating.
+
+  The old `groups` option is still honored as a deprecated alias for `sets`. The implicit
+  auto-grouping by `token.group` has been removed.
+
 ## 2.0.0-beta.7
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -171,17 +171,24 @@ const writer = new Teikn({ themes: [dark, dense, colorblindDark], generators: [n
 await writer.transform(tokens(colors, spacing));
 ```
 
-### `ref(tokenName, usage?)`
+### `ref(tokenName, usageOrOptions?)`
 
 Reference another token by name. References are resolved before generation.
 
 ```typescript
 const colors = group('color', {
   primary: new Color('steelblue'),
-  link: ref('primary'), // resolved to steelblue
+  link: ref('primary'), // flattened → resolved to steelblue
   linkHover: ref('primary', 'Hover state'), // with usage description
+  surface: ref('primary', { link: true }), // aliased → var(--color-primary) in CSS
 });
 ```
+
+By default a reference is flattened into its resolved value. Pass `{ link: true }` to emit a live
+alias instead (`var(--…)` in CSS, `$…` in SCSS, a DTCG alias in Dtcg) so a runtime override of the
+target flows through — the "styling hooks" pattern. `resolveReferences()` still yields the concrete
+value, so audits are unaffected. See [`ref()` in the builders API](docs/api/builders.md#ref) for
+details.
 
 ### `onColors(type, colors)`
 
@@ -630,7 +637,12 @@ const contrastCheck = new ContrastValidatorPlugin({
 
 const fontCheck = new MinFontSizePlugin({ minPx: 12 });
 const touchCheck = new TouchTargetPlugin({ minPx: 44 });
-const distanceCheck = new PerceptualDistancePlugin({ minDeltaE: 5.0 });
+// Declare which colors are meant to be told apart; the plugin measures within
+// each set (ramps, aliases, and unrelated families are never compared).
+const distanceCheck = new PerceptualDistancePlugin({
+  sets: [['danger', 'success', 'warning', 'accent']],
+  minDeltaE: 5.0,
+});
 
 const issues = [
   ...contrastCheck.audit(allTokens),
@@ -642,12 +654,12 @@ const issues = [
 issues.forEach(i => console.warn(`[${i.severity}] ${i.token}: ${i.message}`));
 ```
 
-| Plugin                       | Description                                                                                                                                                                  |
-| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **ContrastValidatorPlugin**  | Validates WCAG contrast ratios (AA: 4.5:1, AAA: 7:1) between foreground/background color pairs                                                                               |
-| **MinFontSizePlugin**        | Warns when font-size tokens fall below an accessibility minimum (default 12px)                                                                                               |
-| **TouchTargetPlugin**        | Warns when size/icon tokens are below minimum touch target size (default 44px per WCAG/Apple HIG)                                                                            |
-| **PerceptualDistancePlugin** | Warns when color tokens are too perceptually similar using [CIEDE2000](https://en.wikipedia.org/wiki/Color_difference#CIEDE2000) (Delta E 2000). Default threshold: ΔE < 5.0 |
+| Plugin                       | Description                                                                                                                                                                                                                                                                                                                                                          |
+| ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **ContrastValidatorPlugin**  | Validates WCAG contrast ratios (AA: 4.5:1, AAA: 7:1) between foreground/background color pairs                                                                                                                                                                                                                                                                       |
+| **MinFontSizePlugin**        | Warns when font-size tokens fall below an accessibility minimum (default 12px)                                                                                                                                                                                                                                                                                       |
+| **TouchTargetPlugin**        | Warns when size/icon tokens are below minimum touch target size (default 44px per WCAG/Apple HIG)                                                                                                                                                                                                                                                                    |
+| **PerceptualDistancePlugin** | Warns when colors in a declared peer `set` are too perceptually similar, using [CIEDE2000](https://en.wikipedia.org/wiki/Color_difference#CIEDE2000) (Delta E 2000). Takes intent explicitly (like `ContrastValidator`'s `pairs`): pass `sets` to gate, `all: true` to compare every pair, or `report: true` for a non-gating ΔE report. Default threshold: ΔE < 5.0 |
 
 #### Delta E 2000 Thresholds
 

--- a/docs/api/builders.md
+++ b/docs/api/builders.md
@@ -181,6 +181,37 @@ References use `{tokenName}` syntax and are resolved by `resolveReferences()` (c
 during generation). This is different from the object-identity-based references used in composed
 values (Transition, BoxShadow) --- `ref()` is string-based and works across any token type.
 
+### Aliased references (`{ link: true }`)
+
+By default a reference is **flattened**: the referenced value is baked into the referencing token.
+Pass `{ link: true }` to instead emit a live **alias** in reference-aware formats, so a runtime
+override of the target flows through:
+
+```typescript
+const colors = group('color', { neutral50: '#fafafa', surface: ref('neutral50', { link: true }) });
+```
+
+| Format                         | `ref('neutral50')` (default) | `ref('neutral50', { link: true })`          |
+| ------------------------------ | ---------------------------- | ------------------------------------------- |
+| CssVars                        | `--color-surface: #fafafa;`  | `--color-surface: var(--color-neutral-50);` |
+| ScssVars                       | `$color-surface: #fafafa;`   | `$color-surface: $color-neutral50;`         |
+| Dtcg                           | concrete color               | `"$value": "{color-neutral50}"`             |
+| Json / JavaScript / TypeScript | concrete value               | concrete value (flattened)                  |
+
+This enables two patterns that flattening cannot:
+
+- **Runtime re-skinning** --- a consumer overriding `--color-neutral50` in a wrapper gets `surface`
+  updated live (the "styling hooks" pattern).
+- **Small theme layers over a shared ramp** --- a theme moves a ramp tier and every semantic token
+  that links to it follows, instead of re-listing each one.
+
+Aliasing is **orthogonal to auditing**: `resolveReferences()` still yields the concrete value, so
+build-time audits (contrast, ΔE) measure the real color. A linked reference to a missing token is
+still a build-time validation error.
+
+To attach both a usage string and `link`, use the object form:
+`ref('neutral50', { usage: '…', link: true })`.
+
 ## dp()
 
 Converts a pixel value from a design spec to its `rem` equivalent (assuming 16px base):

--- a/src/Generators/CssVars.ts
+++ b/src/Generators/CssVars.ts
@@ -124,10 +124,14 @@ export class CssVars extends Generator<CssVarsOpts> {
   }
 
   generateToken(token: Token): string {
-    const { usage, value } = token;
+    const { usage, value, link } = token;
     const key = `--${this.#emit(token.name)}`;
+    // A linked ref (`ref(name, { link: true })`) emits a live `var(--target)`
+    // alias so a runtime override of the target flows through, instead of the
+    // baked-in resolved value.
+    const rhs = link ? `var(--${this.#emit(link)})` : cssValue(value);
 
-    return [usage && `  /* ${usage} */`, `  ${key}: ${cssValue(value)};`].filter(Boolean).join(EOL);
+    return [usage && `  /* ${usage} */`, `  ${key}: ${rhs};`].filter(Boolean).join(EOL);
   }
 
   combinator(tokens: Token[]): string {

--- a/src/Generators/Json.ts
+++ b/src/Generators/Json.ts
@@ -20,9 +20,12 @@ export class Json extends Generator<JsonOpts> {
     };
   }
 
-  generateToken(token: Token): Record<string, Omit<Token, 'name'>> {
+  generateToken(token: Token): Record<string, Omit<Token, 'name' | 'link'>> {
     const { nameTransformer } = this.options;
-    const { name, ...values } = token;
+    // `link` is an output directive for reference-aware formats (CSS/SCSS/DTCG
+    // aliases), not authored data. JSON is a flat value file, so drop it and
+    // keep the resolved concrete `value`.
+    const { name, link, ...values } = token;
     const key = nameTransformer!(name);
 
     return { [key]: values };

--- a/src/Generators/ScssVars.ts
+++ b/src/Generators/ScssVars.ts
@@ -12,7 +12,10 @@ const topoSort = (tokens: Token[], refMap: Map<unknown, string>): Token[] => {
   const deps = new Map<string, string[]>();
 
   for (const token of tokens) {
-    deps.set(token.name, valueDependencies(token.value, refMap));
+    // A linked ref emits `$target`, so the target's `$var` must be declared
+    // first — treat `link` as a dependency alongside any in-value refs.
+    const valueDeps = valueDependencies(token.value, refMap);
+    deps.set(token.name, token.link ? [...valueDeps, token.link] : valueDeps);
   }
 
   const sorted: Token[] = [];
@@ -107,9 +110,12 @@ export class ScssVars extends Scss {
   }
 
   override generateToken(token: Token): string {
-    const { usage, value } = token;
+    const { usage, value, link } = token;
+    // A linked ref (`ref(name, { link: true })`) emits a `$target` alias so the
+    // variable tracks the target instead of baking in its resolved value.
+    const rhs = link ? `$${this.#emit(link)}` : cssValue(value);
 
-    return [usage && `/// ${usage}`, `$${this.#emit(token.name)}: ${cssValue(value)};`]
+    return [usage && `/// ${usage}`, `$${this.#emit(token.name)}: ${rhs};`]
       .filter(Boolean)
       .join(EOL);
   }

--- a/src/Generators/linked-ref.test.ts
+++ b/src/Generators/linked-ref.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, test } from 'bun:test';
+
+import { group, ref } from '../builders.js';
+import { NameConventionPlugin } from '../Plugins/NameConventionPlugin.js';
+import { StripTypePrefixPlugin } from '../Plugins/StripTypePrefixPlugin.js';
+import { resolveReferences } from '../resolve.js';
+import { Teikn } from '../Teikn.js';
+import { tokenKey } from '../token-keys.js';
+import { Color } from '../TokenTypes/Color/index.js';
+import { validate } from '../validate.js';
+
+// End-to-end coverage for top-level linked references: `ref(name, { link: true })`
+// emits a live alias in reference-aware formats (CSS var(), SCSS $var, DTCG
+// alias) while flattening everywhere else and keeping resolveReferences concrete.
+
+const build = (generators: any[], tokens: any[], extra: Record<string, unknown> = {}) =>
+  new Teikn({ generators, validate: false, ...extra }).generateToStrings(tokens);
+
+describe('linked top-level refs', () => {
+  const colors = () =>
+    group('color', {
+      neutral50: '#fafafa',
+      surface: ref('neutral50', { link: true }),
+      baked: ref('neutral50'),
+    });
+
+  test('CssVars emits var() for a linked ref and flattens a plain ref', () => {
+    const out = build([new Teikn.generators.CssVars({ dateFn: () => null })], colors());
+    const css = out.get('tokens.css')!;
+
+    expect(css).toContain('--color-neutral-50: #fafafa;');
+    expect(css).toContain('--color-surface: var(--color-neutral-50);');
+    expect(css).toContain('--color-baked: #fafafa;');
+  });
+
+  test('ScssVars emits $alias, declared after the target', () => {
+    const out = build([new Teikn.generators.ScssVars({ dateFn: () => null })], colors());
+    const scss = out.get('tokens.scss')!;
+
+    expect(scss).toContain('$color-surface: $color-neutral50;');
+    // The target's `$var` must be declared before the alias uses it.
+    expect(scss.indexOf('$color-neutral50:')).toBeLessThan(scss.indexOf('$color-surface:'));
+  });
+
+  test('Dtcg emits a DTCG alias to the target token', () => {
+    const out = build([new Teikn.generators.Dtcg()], colors());
+    const doc = JSON.parse(out.get('tokens.tokens.json')!);
+
+    expect(doc['color-surface'].$value).toBe('{color-neutral50}');
+    expect(doc['color-baked'].$value).not.toBe('{color-neutral50}');
+  });
+
+  test('Json flattens and does not leak the link directive', () => {
+    const out = build([new Teikn.generators.Json()], colors());
+    const doc = JSON.parse(out.get('tokens.json')!);
+
+    expect(doc.colorSurface.value).toBe('#fafafa');
+    expect(doc.colorSurface).not.toHaveProperty('link');
+  });
+
+  test('link works when the target is an object-valued Color token', () => {
+    const tokens = group('color', {
+      brand: new Color('#0066cc'),
+      accent: ref('brand', { link: true }),
+    });
+    const css = build([new Teikn.generators.CssVars({ dateFn: () => null })], tokens).get(
+      'tokens.css',
+    )!;
+    expect(css).toContain('--color-accent: var(--color-brand);');
+  });
+
+  test('linked ref keeps a usage comment', () => {
+    const tokens = group('color', {
+      brand: '#0066cc',
+      accent: ref('brand', { usage: 'Primary accent', link: true }),
+    });
+    const css = build([new Teikn.generators.CssVars({ dateFn: () => null })], tokens).get(
+      'tokens.css',
+    )!;
+    expect(css).toContain('/* Primary accent */');
+    expect(css).toContain('--color-accent: var(--color-brand);');
+  });
+
+  // ─── orthogonality: measurement stays concrete ─────────────────
+
+  test('resolveReferences still yields the concrete value for a linked ref', () => {
+    const resolved = resolveReferences(colors());
+    const surface = resolved.find(t => t.name === 'surface')!;
+
+    // The alias is emitted output; the resolved value remains concrete so
+    // audits (contrast, ΔE) measure the real color.
+    expect(surface.value).toBe('#fafafa');
+    expect(surface.link).toBe('neutral50');
+  });
+
+  // ─── validation still catches a missing target ─────────────────
+
+  test('a linked ref to a missing token is a build-time validation error', () => {
+    const tokens = group('color', { surface: ref('does-not-exist', { link: true }) });
+    const result = validate(tokens);
+    expect(result.valid).toBe(false);
+    expect(result.issues.some(i => /Unresolved reference/.test(i.message))).toBe(true);
+  });
+
+  test('transform() throws for a linked ref to a missing token', () => {
+    const tokens = group('color', { surface: ref('missing', { link: true }) });
+    const t = new Teikn({ generators: [new Teikn.generators.CssVars()] });
+    expect(() => t.generateToStrings(tokens)).toThrow(/validation failed/i);
+  });
+
+  // ─── robustness against name-mangling plugins ──────────────────
+
+  test('NameConventionPlugin keeps the alias pointing at the renamed target', () => {
+    // ScssVars emits names verbatim (no re-casing at emit), so a rename that is
+    // not mirrored onto `link` would produce a dangling `$var`.
+    const out = new Teikn({
+      generators: [new Teikn.generators.ScssVars({ dateFn: () => null })],
+      plugins: [new NameConventionPlugin({ convention: 'camelCase' })],
+      validate: false,
+    }).generateToStrings(colors());
+    const scss = out.get('tokens.scss')!;
+
+    // Both the target definition and the alias use the camelCased name.
+    expect(scss).toContain('$colorNeutral50: #fafafa;');
+    expect(scss).toContain('$colorSurface: $colorNeutral50;');
+  });
+
+  test('StripTypePrefixPlugin keeps the alias pointing at the stripped target', () => {
+    const out = new Teikn({
+      generators: [new Teikn.generators.CssVars({ dateFn: () => null })],
+      plugins: [new StripTypePrefixPlugin()],
+      validate: false,
+    }).generateToStrings(colors());
+    const css = out.get('tokens.css')!;
+
+    expect(css).toContain('--neutral-50: #fafafa;');
+    expect(css).toContain('--surface: var(--neutral-50);');
+  });
+
+  // ─── ref() shape ───────────────────────────────────────────────
+
+  test('ref() without link is unchanged (flattened, no link field)', () => {
+    const [, plain] = group('color', { brand: '#0066cc', plain: ref('brand') });
+    expect(plain!.link).toBeUndefined();
+    expect(plain!.value).toBe('{brand}');
+  });
+
+  test('ref() with a bare usage string still sets usage, not link', () => {
+    const tokens = group('color', { brand: '#0066cc', a: ref('brand', 'note') });
+    const a = tokens.find(t => t.name === 'a')!;
+    expect(a.usage).toBe('note');
+    expect(a.link).toBeUndefined();
+    expect(tokenKey(a)).toBe('color.a');
+  });
+
+  test('qualified link target resolves', () => {
+    const tokens = group('color', {
+      neutral50: '#fafafa',
+      surface: ref('color.neutral50', { link: true }),
+    });
+    const css = build([new Teikn.generators.CssVars({ dateFn: () => null })], tokens).get(
+      'tokens.css',
+    )!;
+    expect(css).toContain('--color-surface: var(--color-neutral-50);');
+  });
+});

--- a/src/Plugins/NameConventionPlugin.ts
+++ b/src/Plugins/NameConventionPlugin.ts
@@ -42,6 +42,12 @@ export class NameConventionPlugin extends Plugin<NameConventionPluginOptions> {
 
     const result: Token = { ...token, name: convert(token.name) };
 
+    // A linked ref stores the target's emitted name; convert it the same way so
+    // the alias still points at the (renamed) target's variable.
+    if (token.link) {
+      result.link = convert(token.link);
+    }
+
     if (token.modes) {
       const convertedModes: ModeValues = {};
 

--- a/src/Plugins/PerceptualDistancePlugin.test.ts
+++ b/src/Plugins/PerceptualDistancePlugin.test.ts
@@ -24,128 +24,205 @@ describe('PerceptualDistancePlugin', () => {
     expect(plugin.transform(token)).toBe(token);
   });
 
-  test('passes when colors are sufficiently distinct', () => {
-    const plugin = new PerceptualDistancePlugin({});
-    const tokens = [makeToken('red', '#ff0000'), makeToken('blue', '#0000ff')];
-    const issues = plugin.audit!(tokens);
-    expect(issues).toHaveLength(0);
-  });
+  // ─── Default: no intent, no judgment ───────────────────────────
 
-  test('warns when colors are too similar', () => {
+  test('does not gate by default — surfaces a single non-gating advisory', () => {
     const plugin = new PerceptualDistancePlugin({});
+    // Two near-identical grays that the old default would have flagged.
     const tokens = [makeToken('gray-a', '#808080'), makeToken('gray-b', '#828282')];
     const issues = plugin.audit!(tokens);
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0]!.severity).toBe('info');
+    expect(issues[0]!.message).toContain('sets');
+    expect(issues[0]!.message).toContain('report');
+  });
+
+  test('does not infer peers from token.group', () => {
+    const plugin = new PerceptualDistancePlugin({});
+    // Same group and similar — the old auto-grouping would have warned.
+    const tokens = [
+      makeToken('gray-a', '#808080', 'neutrals'),
+      makeToken('gray-b', '#828282', 'neutrals'),
+    ];
+    const issues = plugin.audit!(tokens);
+
+    expect(issues.some(i => i.severity === 'warning')).toBe(false);
+  });
+
+  // ─── sets: intent supplied by the author ───────────────────────
+
+  test('warns for similar colors within a declared set', () => {
+    const plugin = new PerceptualDistancePlugin({ sets: [['danger', 'success']] });
+    const tokens = [makeToken('danger', '#dc2626'), makeToken('success', '#16a34a')];
+    // These are distinct; a truly-similar pair should warn.
+    expect(plugin.audit!(tokens)).toHaveLength(0);
+
+    const similar = new PerceptualDistancePlugin({ sets: [['a', 'b']] });
+    const issues = similar.audit!([makeToken('a', '#808080'), makeToken('b', '#828282')]);
     expect(issues).toHaveLength(1);
     expect(issues[0]!.severity).toBe('warning');
     expect(issues[0]!.message).toContain('ΔE');
-    expect(issues[0]!.message).toContain('gray-a');
-    expect(issues[0]!.message).toContain('gray-b');
+    expect(issues[0]!.message).toContain('a');
+    expect(issues[0]!.message).toContain('b');
   });
 
-  test('respects custom minDeltaE', () => {
-    const plugin = new PerceptualDistancePlugin({ minDeltaE: 50 });
-    const tokens = [makeToken('red', '#ff0000'), makeToken('orange', '#ff8800')];
+  test('only compares within a declared set — ramp steps outside it are ignored', () => {
+    const plugin = new PerceptualDistancePlugin({ sets: [['danger', 'success']] });
+    const tokens = [
+      // a ramp — adjacent steps are supposed to be close
+      makeToken('neutral-50', '#fafafa'),
+      makeToken('neutral-100', '#f4f4f5'),
+      // categorical peers — declared as a set
+      makeToken('danger', '#dc2626'),
+      makeToken('success', '#16a34a'),
+    ];
     const issues = plugin.audit!(tokens);
-    expect(issues).toHaveLength(1);
+    // The ramp pair is never compared; the declared peers are distinct.
+    expect(issues).toHaveLength(0);
   });
 
-  test('compares only within specified groups', () => {
-    const plugin = new PerceptualDistancePlugin({ groups: [['gray-a', 'gray-b']] });
+  test('compares only within specified sets, not across them', () => {
+    const plugin = new PerceptualDistancePlugin({ sets: [['gray-a', 'gray-b']] });
     const tokens = [
       makeToken('gray-a', '#808080'),
       makeToken('gray-b', '#828282'),
       makeToken('gray-c', '#838383'),
     ];
     const issues = plugin.audit!(tokens);
-    // Only gray-a vs gray-b compared; gray-c is not in any group
+    // Only gray-a vs gray-b compared; gray-c is in no set.
     expect(issues).toHaveLength(1);
     expect(issues[0]!.message).toContain('gray-a');
     expect(issues[0]!.message).toContain('gray-b');
   });
 
-  test('skips non-color tokens', () => {
-    const plugin = new PerceptualDistancePlugin({});
-    const tokens: Token[] = [
-      makeToken('red', '#ff0000'),
-      { name: 'spacing', type: 'spacing', value: '16px' },
-    ];
-    const issues = plugin.audit!(tokens);
-    expect(issues).toHaveLength(0);
+  test('respects custom minDeltaE within a set', () => {
+    const plugin = new PerceptualDistancePlugin({ minDeltaE: 50, sets: [['red', 'orange']] });
+    const tokens = [makeToken('red', '#ff0000'), makeToken('orange', '#ff8800')];
+    expect(plugin.audit!(tokens)).toHaveLength(1);
   });
 
-  test('handles Color instances as values', () => {
-    const plugin = new PerceptualDistancePlugin({});
-    const tokens = [makeToken('a', new Color('#808080')), makeToken('b', new Color('#818181'))];
-    const issues = plugin.audit!(tokens);
+  test('groups is honored as a deprecated alias for sets', () => {
+    const plugin = new PerceptualDistancePlugin({ groups: [['a', 'b']] });
+    const issues = plugin.audit!([makeToken('a', '#808080'), makeToken('b', '#828282')]);
     expect(issues).toHaveLength(1);
+    expect(issues[0]!.severity).toBe('warning');
   });
 
-  test('skips invalid color values gracefully', () => {
-    const plugin = new PerceptualDistancePlugin({});
-    const tokens: Token[] = [
-      makeToken('red', '#ff0000'),
-      { name: 'bad', type: 'color', value: 'not-a-color' },
-    ];
-    // Should not throw; skips the invalid token
-    const issues = plugin.audit!(tokens);
-    expect(issues).toHaveLength(0);
-  });
-
-  test('includes actual deltaE value in the message', () => {
-    const plugin = new PerceptualDistancePlugin({});
-    const tokens = [makeToken('a', '#808080'), makeToken('b', '#808081')];
-    const issues = plugin.audit!(tokens);
-    expect(issues).toHaveLength(1);
-    // The message should contain a numeric ΔE value
-    const match = issues[0]!.message.match(/ΔE = (\d+\.?\d*)/);
-    expect(match).not.toBeNull();
-    const deltaE = parseFloat(match![1]!);
-    expect(deltaE).toBeGreaterThan(0);
-    expect(deltaE).toBeLessThan(5);
-  });
-
-  test('compares all pairs within same auto-group when no groups specified', () => {
-    const plugin = new PerceptualDistancePlugin({ minDeltaE: 100 });
+  test('sets wins over groups when both are given', () => {
+    const plugin = new PerceptualDistancePlugin({ sets: [['a', 'b']], groups: [['a', 'b', 'c']] });
     const tokens = [
-      makeToken('a', '#ff0000', 'warm'),
-      makeToken('b', '#00ff00', 'warm'),
-      makeToken('c', '#0000ff', 'cool'),
+      makeToken('a', '#808080'),
+      makeToken('b', '#828282'),
+      makeToken('c', '#838383'),
     ];
-    // a and b are in "warm" group (1 pair), c is alone in "cool" (0 pairs)
-    const issues = plugin.audit!(tokens);
-    expect(issues).toHaveLength(1);
+    // Uses `sets` (one pair), not `groups` (three pairs).
+    expect(plugin.audit!(tokens)).toHaveLength(1);
   });
 
-  test('ungrouped tokens are compared together', () => {
-    const plugin = new PerceptualDistancePlugin({ minDeltaE: 100 });
+  // ─── all: explicit opt-in to all-pairs gating ──────────────────
+
+  test('all: true compares every color pair', () => {
+    const plugin = new PerceptualDistancePlugin({ minDeltaE: 100, all: true });
     const tokens = [
       makeToken('a', '#ff0000'),
       makeToken('b', '#00ff00'),
       makeToken('c', '#0000ff'),
     ];
-    // All 3 are ungrouped => same auto-group => 3 pairs
+    // 3 pairs, all under the huge threshold.
+    expect(plugin.audit!(tokens)).toHaveLength(3);
+  });
+
+  test('all: true ignores token.group boundaries', () => {
+    const plugin = new PerceptualDistancePlugin({ minDeltaE: 100, all: true });
+    const tokens = [makeToken('a', '#ff0000', 'warm'), makeToken('b', '#00ff00', 'cool')];
+    // Different groups, but `all` compares them anyway.
+    expect(plugin.audit!(tokens)).toHaveLength(1);
+  });
+
+  // ─── report: non-gating measurement ────────────────────────────
+
+  test('report: true emits info findings for every pair, worst-first', () => {
+    const plugin = new PerceptualDistancePlugin({ report: true });
+    const tokens = [
+      makeToken('white', '#ffffff'),
+      makeToken('near-white', '#fefefe'),
+      makeToken('black', '#000000'),
+    ];
     const issues = plugin.audit!(tokens);
+
+    // 3 pairs, all reported, none gating.
     expect(issues).toHaveLength(3);
+    expect(issues.every(i => i.severity === 'info')).toBe(true);
+
+    // Worst (most similar) first: white vs near-white has the smallest ΔE.
+    expect(issues[0]!.message).toContain('white');
+    expect(issues[0]!.message).toContain('near-white');
+
+    const deltas = issues.map(i => parseFloat(i.message.match(/ΔE = (\d+\.?\d*)/)![1]!));
+    expect(deltas).toEqual(deltas.toSorted((a, b) => a - b));
   });
 
-  test('does not compare tokens across different groups', () => {
-    const plugin = new PerceptualDistancePlugin({});
+  test('report: true respects sets when provided', () => {
+    const plugin = new PerceptualDistancePlugin({ report: true, sets: [['a', 'b']] });
     const tokens = [
-      makeToken('gray-a', '#808080', 'neutrals'),
-      makeToken('gray-b', '#828282', 'accents'),
+      makeToken('a', '#808080'),
+      makeToken('b', '#828282'),
+      makeToken('c', '#000000'),
     ];
-    // Different groups — no comparison, no warning
     const issues = plugin.audit!(tokens);
-    expect(issues).toHaveLength(0);
+    // Only the declared pair is measured.
+    expect(issues).toHaveLength(1);
+    expect(issues[0]!.severity).toBe('info');
+    expect(issues[0]!.message).toContain('a');
+    expect(issues[0]!.message).toContain('b');
   });
 
-  test('warns for similar tokens within same auto-group', () => {
-    const plugin = new PerceptualDistancePlugin({});
-    const tokens = [
-      makeToken('gray-a', '#808080', 'neutrals'),
-      makeToken('gray-b', '#828282', 'neutrals'),
-    ];
+  test('report mode never gates, even for identical colors', () => {
+    const plugin = new PerceptualDistancePlugin({ report: true, all: true });
+    const tokens = [makeToken('a', '#123456'), makeToken('alias', '#123456')];
     const issues = plugin.audit!(tokens);
     expect(issues).toHaveLength(1);
+    expect(issues[0]!.severity).toBe('info');
+    expect(issues[0]!.message).toContain('ΔE = 0');
+  });
+
+  // ─── robustness ────────────────────────────────────────────────
+
+  test('handles Color instances as values', () => {
+    const plugin = new PerceptualDistancePlugin({ sets: [['a', 'b']] });
+    const tokens = [makeToken('a', new Color('#808080')), makeToken('b', new Color('#818181'))];
+    expect(plugin.audit!(tokens)).toHaveLength(1);
+  });
+
+  test('skips non-color tokens', () => {
+    const plugin = new PerceptualDistancePlugin({ all: true });
+    const tokens: Token[] = [
+      makeToken('red', '#ff0000'),
+      { name: 'spacing', type: 'spacing', value: '16px' },
+    ];
+    const issues = plugin.audit!(tokens);
+    expect(issues.some(i => i.severity === 'warning')).toBe(false);
+  });
+
+  test('skips invalid color values gracefully', () => {
+    const plugin = new PerceptualDistancePlugin({ all: true });
+    const tokens: Token[] = [
+      makeToken('red', '#ff0000'),
+      { name: 'bad', type: 'color', value: 'not-a-color' },
+    ];
+    // Should not throw; skips the invalid token, leaving no comparable pair.
+    expect(plugin.audit!(tokens)).toHaveLength(0);
+  });
+
+  test('includes the actual ΔE value in gating messages', () => {
+    const plugin = new PerceptualDistancePlugin({ sets: [['a', 'b']] });
+    const issues = plugin.audit!([makeToken('a', '#808080'), makeToken('b', '#808081')]);
+    expect(issues).toHaveLength(1);
+    const match = issues[0]!.message.match(/ΔE = (\d+\.?\d*)/);
+    expect(match).not.toBeNull();
+    const deltaE = parseFloat(match![1]!);
+    expect(deltaE).toBeGreaterThan(0);
+    expect(deltaE).toBeLessThan(5);
   });
 });

--- a/src/Plugins/PerceptualDistancePlugin.ts
+++ b/src/Plugins/PerceptualDistancePlugin.ts
@@ -3,10 +3,50 @@ import { Color } from '../TokenTypes/Color/index.js';
 import type { AuditIssue } from './Plugin.js';
 import { Plugin } from './Plugin.js';
 
-type PerceptualDistancePluginOptions = { minDeltaE?: number; groups?: string[][] } & Record<
-  string,
-  unknown
->;
+/**
+ * "These two colors are too similar" is a judgment, and judgment needs intent:
+ * it presumes the two colors are *meant* to be told apart. Ramps (adjacent steps
+ * are supposed to be close), aliases (ΔE 0 by design), and unrelated families are
+ * not mutually-distinguishable peers, and there is no reliable way to infer which
+ * tokens are peers from their names or structure without baking one house style
+ * into a general tool.
+ *
+ * So this plugin takes the intent as input — the same model as
+ * `ContrastValidatorPlugin`, which never guesses foreground vs. background but is
+ * handed the pairs. Declare the peer `sets` that must be mutually distinguishable
+ * and it measures within each. Measurement itself is always fair game, so a
+ * non-gating `report` mode is available too. Nothing is compared by default.
+ */
+type PerceptualDistancePluginOptions = {
+  /** Minimum acceptable ΔE00 between two tokens in a peer set. Default: 5.0 */
+  minDeltaE?: number;
+  /**
+   * Peer sets: each inner array lists token names that must be mutually
+   * distinguishable. The plugin measures every pair *within* each set and warns
+   * when ΔE00 falls below `minDeltaE`. Tokens not in any set are ignored.
+   */
+  sets?: string[][];
+  /**
+   * @deprecated Renamed to {@link PerceptualDistancePluginOptions.sets}.
+   * Still honored (as an alias) for backward compatibility; `sets` wins when
+   * both are given.
+   */
+  groups?: string[][];
+  /**
+   * Opt in to comparing *every* pair of color tokens and gating below
+   * `minDeltaE`. This asserts that all color tokens are mutually-distinguishable
+   * peers — usually false once ramps and aliases exist — so it is off by default
+   * and must be requested explicitly.
+   */
+  all?: boolean;
+  /**
+   * Report mode: emit the pairwise ΔE00 as non-gating `info` findings
+   * (worst/most-similar first) with no pass/fail. Measures within `sets`/`groups`
+   * when provided, otherwise across all color pairs. Takes precedence over
+   * gating — use it to inspect the data and decide intent yourself.
+   */
+  report?: boolean;
+} & Record<string, unknown>;
 
 const toColor = (t: Token): Color | null => {
   try {
@@ -16,68 +56,94 @@ const toColor = (t: Token): Color | null => {
   }
 };
 
+type Measurement = { a: Token; b: Token; deltaE: number };
+
+const round2 = (n: number): number => Math.round(n * 100) / 100;
+
+/** Measure ΔE00 for every pair of the named tokens, skipping unknown/invalid. */
+const measurePairs = (names: string[], tokenMap: Map<string, Token>): Measurement[] => {
+  const measurements: Measurement[] = [];
+
+  for (let i = 0; i < names.length; i++) {
+    for (let j = i + 1; j < names.length; j++) {
+      const tA = tokenMap.get(names[i]!);
+      const tB = tokenMap.get(names[j]!);
+
+      if (!tA || !tB) {
+        continue;
+      }
+
+      const cA = toColor(tA);
+      const cB = toColor(tB);
+
+      if (!cA || !cB) {
+        continue;
+      }
+
+      measurements.push({ a: tA, b: tB, deltaE: cA.deltaE(cB) });
+    }
+  }
+
+  return measurements;
+};
+
 export class PerceptualDistancePlugin extends Plugin<PerceptualDistancePluginOptions> {
   tokenType: string = 'color';
   outputType: RegExp = /.*/;
 
   override audit(tokens: Token[]): AuditIssue[] {
-    const { minDeltaE = 5.0, groups } = this.options;
+    const { minDeltaE = 5.0, sets, groups, all, report } = this.options;
+    const peerSets = sets ?? groups;
 
     const colorTokens = tokens.filter(t => t.type === 'color');
     const tokenMap = new Map(colorTokens.map(t => [t.name, t]));
+    const allNames = colorTokens.map(t => t.name);
 
-    const comparePairs = (names: string[]): AuditIssue[] => {
-      const issues: AuditIssue[] = [];
+    // Report mode: pure measurement, no judgment. Emit every measured pair as a
+    // non-gating `info`, most-similar first, so the author (or a downstream
+    // tool) can decide what counts as "too close".
+    if (report) {
+      const scope = peerSets ?? [allNames];
+      const measurements = scope
+        .flatMap(names => measurePairs(names, tokenMap))
+        .toSorted((x, y) => x.deltaE - y.deltaE);
 
-      for (let i = 0; i < names.length; i++) {
-        for (let j = i + 1; j < names.length; j++) {
-          const tA = tokenMap.get(names[i]!);
-          const tB = tokenMap.get(names[j]!);
-
-          if (!tA || !tB) {
-            continue;
-          }
-
-          const cA = toColor(tA);
-          const cB = toColor(tB);
-
-          if (!cA || !cB) {
-            continue;
-          }
-
-          const dE = cA.deltaE(cB);
-          const rounded = Math.round(dE * 100) / 100;
-
-          if (dE < minDeltaE) {
-            issues.push({
-              severity: 'warning',
-              token: tA.name,
-              message: `Colors "${tA.name}" and "${tB.name}" are very similar (ΔE = ${rounded}), minimum is ${minDeltaE}`,
-            });
-          }
-        }
-      }
-
-      return issues;
-    };
-
-    if (groups) {
-      return groups.flatMap(comparePairs);
+      return measurements.map(({ a, b, deltaE }) => ({
+        severity: 'info' as const,
+        token: a.name,
+        message: `ΔE = ${round2(deltaE)} between "${a.name}" and "${b.name}"`,
+      }));
     }
 
-    // Auto-group by token.group (set by the group() builder)
-    const byGroup = new Map<string, string[]>();
+    const gate = (measurements: Measurement[]): AuditIssue[] =>
+      measurements
+        .filter(({ deltaE }) => deltaE < minDeltaE)
+        .map(({ a, b, deltaE }) => ({
+          severity: 'warning' as const,
+          token: a.name,
+          message: `Colors "${a.name}" and "${b.name}" are very similar (ΔE = ${round2(deltaE)}), minimum is ${minDeltaE}`,
+        }));
 
-    for (const t of colorTokens) {
-      const g = t.group ?? '_ungrouped';
-
-      if (!byGroup.has(g)) {
-        byGroup.set(g, []);
-      }
-
-      byGroup.get(g)!.push(t.name);
+    // Declared peer sets — the recommended, intent-explicit mode.
+    if (peerSets) {
+      return peerSets.flatMap(names => gate(measurePairs(names, tokenMap)));
     }
 
-    return [...byGroup.values()].flatMap(comparePairs);
+    // Explicit opt-in to all-pairs gating.
+    if (all) {
+      return gate(measurePairs(allNames, tokenMap));
+    }
+
+    // No intent declared → no judgment. Surface a single non-gating advisory so
+    // the plugin isn't silently inert.
+    return [
+      {
+        severity: 'info',
+        token: '',
+        message:
+          'PerceptualDistancePlugin compared no colors: declare peer `sets` to gate, ' +
+          'pass `all: true` to compare every pair, or `report: true` for a non-gating ΔE report.',
+      },
+    ];
   }
 }

--- a/src/Plugins/StripTypePrefixPlugin.ts
+++ b/src/Plugins/StripTypePrefixPlugin.ts
@@ -31,6 +31,16 @@ export class StripTypePrefixPlugin extends Plugin {
   tokenType: RegExp = /.*/;
 
   override transform(token: Token): Token {
-    return { ...token, name: deriveShortName(token.name, token.type) };
+    const result: Token = { ...token, name: deriveShortName(token.name, token.type) };
+
+    // A linked ref stores the target's emitted (type-prefixed) name; strip the
+    // same prefix so the alias still points at the target's stripped name.
+    // Same-type aliases (the common case) share the prefix; a cross-type link
+    // whose target carries a different type prefix is left as-is.
+    if (token.link) {
+      result.link = deriveShortName(token.link, token.type);
+    }
+
+    return result;
   }
 }

--- a/src/Teikn.ts
+++ b/src/Teikn.ts
@@ -44,9 +44,42 @@ import { validate } from './validate.js';
 /**
  * Prefix each token's name with its type, joined by a hyphen.
  * Generators' nameTransformers (kebabCase, camelCase, etc.) handle final formatting.
+ *
+ * A linked reference (`ref(name, { link: true })`) carries the *authored* target
+ * name in `token.link`. Rewrite it here to the target's final prefixed name so
+ * reference-aware generators can emit the alias directly. The rewrite runs
+ * against the pre-prefix key index, matching how the target's own name is
+ * derived, so bare and qualified link targets both resolve.
  */
-const prefixTokenNames = (tokens: Token[]): Token[] =>
-  tokens.map(token => ({ ...token, name: `${token.type}-${token.name}` }));
+const prefixedName = (token: Token): string => `${token.type}-${token.name}`;
+
+const prefixTokenNames = (tokens: Token[]): Token[] => {
+  const finalName = prefixedName;
+  const linked = tokens.some(token => token.link);
+
+  if (!linked) {
+    return tokens.map(token => ({ ...token, name: finalName(token) }));
+  }
+
+  const keyIndex = buildKeyAliasIndex(tokens.map(token => tokenKey(token)).filter(Boolean));
+  const keyToFinal = new Map(tokens.map(token => [tokenKey(token), finalName(token)]));
+
+  return tokens.map(token => {
+    const name = finalName(token);
+
+    if (!token.link) {
+      return { ...token, name };
+    }
+
+    const resolved = resolveKey(token.link, keyIndex);
+    // A missing/ambiguous target is already reported by validate() (which runs
+    // on the pre-resolve tokens). Leave `link` untouched here so that path owns
+    // the error message; generators fall back to the flattened value.
+    const linkFinal = resolved.status === 'ok' ? keyToFinal.get(resolved.key) : undefined;
+
+    return { ...token, name, link: linkFinal ?? token.link };
+  });
+};
 
 /**
  * Apply theme layers to tokens, merging each layer's overrides into token.modes.

--- a/src/Token.ts
+++ b/src/Token.ts
@@ -88,6 +88,19 @@ export type Token = {
   deprecated?: boolean;
   /** Set by `DeprecationPlugin` when a replacement token is named. */
   replacement?: string;
+  /**
+   * Set by `ref(name, { link: true })`. Marks this token as a *linked*
+   * reference: reference-aware generators emit an alias to the referenced
+   * token (CSS `var(--…)`, SCSS `$…`, a DTCG `{token}` alias) instead of the
+   * flattened value, so a runtime override of the target flows through.
+   *
+   * The stored string is the referenced token's emitted name — the bare
+   * authored name at authoring time, rewritten to the final prefixed name by
+   * the pipeline (see `prefixTokenNames`) so generators can emit it directly.
+   * `value` is still resolved to the concrete value, so audits and
+   * non-aliasing generators are unaffected.
+   */
+  link?: string;
 };
 
 export type TokenInput = TokenValue | [value: TokenValue, usage: string] | TokenInputObject;
@@ -96,6 +109,8 @@ export type TokenInputObject = {
   value: TokenValue | CompositeValue;
   usage?: string;
   modes?: ModeValues;
+  /** Set by `ref(name, { link: true })`; see {@link Token.link}. */
+  link?: string;
 };
 
 export type CompositeInput = Record<string, TokenValue>;

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -47,7 +47,7 @@ const resolveTokenInput = (name: string, input: TokenInput): Omit<Token, 'type'>
   }
 
   if (isTokenInputObject(input)) {
-    const { value, usage, modes } = input;
+    const { value, usage, modes, link } = input;
     const token: Omit<Token, 'type'> = { name, value };
 
     if (usage) {
@@ -56,6 +56,10 @@ const resolveTokenInput = (name: string, input: TokenInput): Omit<Token, 'type'>
 
     if (modes) {
       token.modes = modes;
+    }
+
+    if (link) {
+      token.link = link;
     }
 
     return token;
@@ -427,9 +431,32 @@ export const theme = (
   return { name, tokenNames, overrides: merged };
 };
 
+/** Options for {@link ref}. */
+export type RefOptions = {
+  /** Documentation string, same as passing a bare string as the second arg. */
+  usage?: string;
+  /**
+   * Emit this reference as a live *alias* to the target rather than baking in
+   * its resolved value. Reference-aware generators (CssVars, ScssVars, Dtcg)
+   * emit `var(--target)` / `$target` / `{target}`; every other generator, and
+   * `resolveReferences()`, still see the flattened concrete value. Default:
+   * `false` (flatten).
+   *
+   * Use this for the "styling hooks" pattern — a consumer that overrides the
+   * target token at runtime gets the aliasing token updated live — and for
+   * small theme layers that move a shared ramp tier and let every semantic
+   * token referencing it follow.
+   */
+  link?: boolean;
+};
+
 /**
  * Create a token that references another token by name.
  * References are resolved before plugins run.
+ *
+ * The second argument may be a bare usage string, or an options object. Pass
+ * `{ link: true }` to emit the reference as a live alias in reference-aware
+ * formats instead of flattening it (see {@link RefOptions.link}).
  *
  * @example
  * ```ts
@@ -437,18 +464,29 @@ export const theme = (
  *   primary: '#0066cc',
  *   link: ref('primary'),
  *   linkHover: ref('primary', 'Hover state for links'),
+ *   // Emits `var(--color-primary)` in CSS, resolved by the browser at runtime:
+ *   surface: ref('primary', { link: true }),
  * });
  * ```
  */
-export const ref = (tokenName: string, usage?: string): TokenInputObject => {
+export const ref = (tokenName: string, usageOrOptions?: string | RefOptions): TokenInputObject => {
   if (!tokenName || typeof tokenName !== 'string') {
     throw new Error(`ref(): token name must be a non-empty string`);
   }
+
+  const { usage, link } =
+    typeof usageOrOptions === 'string'
+      ? { usage: usageOrOptions, link: false }
+      : (usageOrOptions ?? {});
 
   const result: TokenInputObject = { value: `{${tokenName}}` };
 
   if (usage) {
     result.usage = usage;
+  }
+
+  if (link) {
+    result.link = tokenName;
   }
 
   return result;

--- a/src/dtcg/serialize.ts
+++ b/src/dtcg/serialize.ts
@@ -76,7 +76,11 @@ const hoistGroupTypes = (obj: Record<string, any>): void => {
 
 const tokenToDtcg = (token: Token, refMap?: DtcgRefMap): DtcgToken => {
   const dtcgType = teiknTypeToDtcg(token.type);
-  const dtcgValue = teiknValueToDtcg(token.value, token.type, refMap);
+  // A linked ref (`ref(name, { link: true })`) serializes as a DTCG alias to
+  // the target token, mirroring CSS `var(--…)`, instead of the flattened value.
+  const dtcgValue = token.link
+    ? `{${token.link}}`
+    : teiknValueToDtcg(token.value, token.type, refMap);
 
   const result: DtcgToken = { $value: dtcgValue as any, $type: dtcgType };
 


### PR DESCRIPTION
Two small moves toward the neutrality that's already teikn's whole point: author values once → many formats, and never infer token relationships the author didn't declare.

## Issue 1 — opt-in aliased top-level `ref()`

A top-level `ref()` is resolved to a concrete value before generation, so there was no way to emit a `var()` alias. This adds an opt-in:

```ts
const colors = group('color', {
  neutral50: '#fafafa',
  surface: ref('neutral50', { link: true }),
});
```

| Format | `ref('neutral50')` (default) | `ref('neutral50', { link: true })` |
| --- | --- | --- |
| CssVars | `--color-surface: #fafafa;` | `--color-surface: var(--color-neutral-50);` |
| ScssVars | `$color-surface: #fafafa;` | `$color-surface: $color-neutral50;` |
| Dtcg | concrete color | `"$value": "{color-neutral50}"` |
| Json / JavaScript / TypeScript | concrete value | concrete value (flattened) |

Flattening stays the default. This enables runtime re-skinning (the "styling hooks" pattern) and small theme layers that move a shared ramp tier.

Design guarantees called for in the issue:
- **Orthogonal to auditing** — `resolveReferences()` still yields the concrete value, so contrast/ΔE audits measure the real color. `link` is separate metadata.
- **Validation preserved** — a linked ref to a missing token is still a build-time error.
- **Rename-safe** — `NameConventionPlugin` and `StripTypePrefixPlugin` carry `link` through their name transforms; the internal `link` directive is stripped from Json output.

`ref()`'s second argument now accepts either a usage string (unchanged) or `{ usage?, link? }`.

## Issue 2 — `PerceptualDistancePlugin` takes intent as input

The plugin auto-grouped color tokens by `token.group` and gated below a ΔE threshold by default, flagging ramp steps and aliases that are *meant* to be close. "Too similar" is a judgment that needs author intent. Reworked to mirror `ContrastValidatorPlugin`'s model — intent is supplied, not inferred:

- `sets: [[…]]` — gate within declared peer sets (recommended)
- `all: true` — explicit opt-in to all-pairs gating
- `report: true` — non-gating pairwise ΔE, most-similar first
- default — compares nothing; emits a single advisory instead of gating

The implicit auto-grouping by `token.group` is removed. `groups` is kept as a deprecated alias for `sets`.

## Tests & docs

- New `src/Generators/linked-ref.test.ts` (14 cases): CSS/SCSS/DTCG aliasing, JSON flatten + no `link` leak, object-valued targets, usage comments, `resolveReferences` stays concrete, missing-target validation, name-mangling-plugin robustness, `ref()` shape.
- Rewritten `PerceptualDistancePlugin.test.ts` (19 cases) for the new modes.
- Updated `README.md`, `docs/api/builders.md`, `CHANGELOG.md` (new Unreleased section).

## Verification

`bun run build` (tsc), `bun test` (2172 pass), `vitest run` (2172 pass — no existing generator snapshot changed), `oxlint`, `oxfmt --check` all clean.

## Notes
- One behavioral change (`PerceptualDistancePlugin` default no longer gates), softened by the `groups` alias — targets beta.8.