### PR TITLE
Bump version to 2.0.0-beta.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 2.0.0-beta.8
 
 ### Added
 

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@shawnrice/teikn",
-  "version": "2.0.0-beta.7",
+  "version": "2.0.0-beta.8",
   "exports": {
     ".": "./index.ts",
     "./color": "./src/TokenTypes/Color/index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teikn",
-  "version": "2.0.0-beta.7",
+  "version": "2.0.0-beta.8",
   "description": "Generate design tokens",
   "keywords": [
     "design",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '2.0.0-beta.7';
+export const version = '2.0.0-beta.8';


### PR DESCRIPTION
Version bump for the next beta.

- Renames the staged CHANGELOG **Unreleased** section to **2.0.0-beta.8**, covering the two changes from #49:
  - `ref(name, { link: true })` — opt-in aliased top-level references (`var(--…)` / `$…` / DTCG alias).
  - `PerceptualDistancePlugin` now takes intent explicitly (`sets` / `all` / `report`); auto-grouping by `token.group` removed, `groups` kept as a deprecated alias.
- Bumps the version in `package.json`, `jsr.json`, and `src/version.ts` from `2.0.0-beta.7` → `2.0.0-beta.8`.

Build + tests green (`tsc`, `bun test` 2172 pass).