### PR TITLE
Bump version to 2.0.0-beta.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 2.0.0-beta.9
 
 ### Added
 

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@shawnrice/teikn",
-  "version": "2.0.0-beta.8",
+  "version": "2.0.0-beta.9",
   "exports": {
     ".": "./index.ts",
     "./color": "./src/TokenTypes/Color/index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teikn",
-  "version": "2.0.0-beta.8",
+  "version": "2.0.0-beta.9",
   "description": "Generate design tokens",
   "keywords": [
     "design",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '2.0.0-beta.8';
+export const version = '2.0.0-beta.9';


### PR DESCRIPTION
Version bump for the next beta.

- Renames the staged CHANGELOG **Unreleased** section to **2.0.0-beta.9**, covering #51:
  - **Added:** `PalettePlugin` `space` option (keep ramps in the authored/perceptual color space) + `Color#space` getter.
  - **Fixed:** two audit passes of correctness bugs (color gamut clamp, SCSS map commas, DTCG alias paths, linked-ref remap, named colors, Transition/BoxShadow/Border parsing, hue wrapping, `matches()`/CLI/util edges, …).
- Bumps `package.json`, `jsr.json`, and `src/version.ts` from `2.0.0-beta.8` → `2.0.0-beta.9`.

Build + tests green (`tsc`, `bun test` 2205).